### PR TITLE
Fix dimensions for export variable

### DIFF
--- a/core/src/bufr/BufrReader/Exports/Variables/RemappedBrightnessTemperatureVariable.cpp
+++ b/core/src/bufr/BufrReader/Exports/Variables/RemappedBrightnessTemperatureVariable.cpp
@@ -64,9 +64,6 @@ namespace bufr {
         int nobs = (radObj->getDims())[0];
         int nchn = (radObj->getDims())[1];
 
-        log::info()  << "RemappedBrightnessTemperatureVariable: nobs = " << nobs << std::endl;
-        log::info()  << "RemappedBrightnessTemperatureVariable: nchn = " << nchn << std::endl;
-
         // Declare and initialize scanline array
         // scanline has the same dimension as fovn
         std::vector<int> scanline(fovnObj->size(), DataObject<int>::missingValue());

--- a/core/src/bufr/BufrReader/Exports/Variables/RemappedBrightnessTemperatureVariable.cpp
+++ b/core/src/bufr/BufrReader/Exports/Variables/RemappedBrightnessTemperatureVariable.cpp
@@ -64,6 +64,9 @@ namespace bufr {
         int nobs = (radObj->getDims())[0];
         int nchn = (radObj->getDims())[1];
 
+        log::info()  << "RemappedBrightnessTemperatureVariable: nobs = " << nobs << std::endl;
+        log::info()  << "RemappedBrightnessTemperatureVariable: nchn = " << nchn << std::endl;
+
         // Declare and initialize scanline array
         // scanline has the same dimension as fovn
         std::vector<int> scanline(fovnObj->size(), DataObject<int>::missingValue());
@@ -97,17 +100,19 @@ namespace bufr {
         // Perform FFT image remapping
         // input only variables: nobs, nchn obstime, fovn, channel
         // input & output variables: btobs, scanline, error_status
-        int error_status;
-        ATMS_Spatial_Average_f(nobs, nchn, &obstime, &fovn, &channel, &btobs,
-                                           &scanline, &error_status);
+        if (nobs > 0) {
+            int error_status;
+	    ATMS_Spatial_Average_f(nobs, nchn, &obstime, &fovn, &channel, &btobs,
+                                               &scanline, &error_status);
+        }
 
         // Export remapped observation (btobs)
         return DataObjectBuilder::make<float>(btobs,
                                               getExportName(),
                                               groupByField_,
-                                              fovnObj->getDims(),
-                                              fovnObj->getPath(),
-                                              fovnObj->getDimPaths());
+                                              radObj->getDims(),
+                                              radObj->getPath(),
+                                              radObj->getDimPaths());
     }
 
     void RemappedBrightnessTemperatureVariable::checkKeys(const BufrDataMap& map)

--- a/test/testinput/bufrtest_atms_mapping.yaml
+++ b/test/testinput/bufrtest_atms_mapping.yaml
@@ -1,5 +1,3 @@
-# (C) Copyright 2022 NOAA/NWS/NCEP/EMC
-
 bufr:
   variables:
     # MetaData
@@ -53,9 +51,19 @@ bufr:
       query: "*/ATMSCH/CHNM"
 
     # ObsValue
-    # Brightness Temperature
-    brightnessTemperature:
-      query: "*/ATMSCH/TMBR"
+    # Remapped Brightness Temperature
+    remappedBT:
+      remappedBrightnessTemperature:
+        fieldOfViewNumber: "*/FOVN"
+        sensorChannelNumber: "*/ATMSCH/CHNM"
+        brightnessTemperature: "*/ATMSCH/TMANT"
+        obsTime:
+          year: "*/YEAR"
+          month: "*/MNTH"
+          day: "*/DAYS"
+          hour: "*/HOUR"
+          minute: "*/MINU"
+          second: "*/SECO"
 
   splits:
     satId:
@@ -64,6 +72,7 @@ bufr:
         map:
           _224: npp
           _225: n20
+          _226: n21
 
 encoder:
   type: netcdf
@@ -151,9 +160,9 @@ encoder:
       longName: "Sensor Channel Number"
 
     # ObsValue
-    # Brightness Temperature
+    # Remapped Brightness Temperature
     - name: "ObsValue/brightnessTemperature"
-      source: variables/brightnessTemperature
-      longName: "Brightness Temperature"
+      source: variables/remappedBT
+      longName: "3-by-3 Averaged Brightness Temperature"
       units: "K"
       chunks: [10000, 22]

--- a/test/testoutput/bufrtest_atms_n20.nc
+++ b/test/testoutput/bufrtest_atms_n20.nc
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a90a0b9dac815f4d894cd81e9977ec661995a4ce1b57fdde05be6181a3177521
-size 110249
+oid sha256:b2a7698b0b0c974c76e00f5b5ea5dcdec28e1db5d32f958c55682fe3239e1bb0
+size 110918


### PR DESCRIPTION
This PR fixes an [issue](https://github.com/NOAA-EMC/bufr-query/issues/5) found in exporting the remapped brightness temperature to the container.  
```
group: ObsValue {
  variables:
        float brightnessTemperature(Location) ;
                brightnessTemperature:_FillValue = 3.402823e+38f ;
                brightnessTemperature:long_name = "3-by-3 Averaged Brightness Temperature" ;
                brightnessTemperature:units = "K" ;
  } // group ObsValue

```

The dimension of brighenssTemperature should be 2D (Location, Channel)
