### PR TITLE
Remove checking name consistency of data path.

### DIFF
--- a/core/include/bufr/DataObject.h
+++ b/core/include/bufr/DataObject.h
@@ -438,17 +438,6 @@ namespace bufr {
             throw eckit::BadParameter(str.str());
           }
         }
-
-        for (const auto& path : other->dimPaths_)
-        {
-          if (std::find(dimPaths_.begin(), dimPaths_.end(), path) == dimPaths_.end())
-          {
-            std::ostringstream str;
-            str << "Cannot append data with different dimension paths.";
-            throw eckit::BadParameter(str.str());
-          }
-        }
-
         data_.insert(data_.end(), other->data_.begin(), other->data_.end());
       }
 
@@ -731,17 +720,6 @@ namespace bufr {
             throw eckit::BadParameter(str.str());
           }
         }
-
-        for (const auto& path : other->dimPaths_)
-        {
-          if (std::find(dimPaths_.begin(), dimPaths_.end(), path) == dimPaths_.end())
-          {
-            std::ostringstream str;
-            str << "Cannot append data with different dimension paths.";
-            throw eckit::BadParameter(str.str());
-          }
-        }
-
         data_.insert(data_.end(), other->data_.begin(), other->data_.end());
       }
 


### PR DESCRIPTION
While merging/appending containers, bufr-query would check if the dimensions (other than Location) are consistent among containers to be merged by checking the name of the data paths.  However, there are circumstances as described in [Issue #13 ](https://github.com/NOAA-EMC/bufr-query/issues/13) that the containers have different path names, but their dimensions are actually the same.  So, this PR is to remove the check on the name of the dimension for containers to be merged.  