### PR TITLE
Move install location for python packages to "lib/pythonX.Y/site-packages"

### DIFF
--- a/cmake/Targets.cmake
+++ b/cmake/Targets.cmake
@@ -104,17 +104,17 @@ macro(AddPyLib libname pyname pybasename)
     ApplyBaseSettings(${libname})
     set_target_properties( ${libname} PROPERTIES FOLDER "Libs/Python/${pybasename}")
     set_target_properties( ${libname} PROPERTIES
-        ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib/${pybasename}/${pyname}"
-        LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib/${pybasename}/${pyname}"
-        RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin/${pybasename}/${pyname}"
+        ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib/${pybasename}/site-packages/${pyname}"
+        LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib/${pybasename}/site-packages/${pyname}"
+        RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin/${pybasename}/site-packages/${pyname}"
         INSTALL_RPATH "${CMAKE_INSTALL_FULL_LIBDIR}"
         )
     export( TARGETS ${libname} APPEND FILE "${PROJECT_TARGETS_FILE}" )
     install( TARGETS ${libname}
         EXPORT ${PROJECT_NAME}-targets
         RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
-        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}/${pybasename}/${pyname}
-        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}/${pybasename}/${pyname}
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}/${pybasename}/site-packages/${pyname}
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}/${pybasename}/site-packages/${pyname}
         COMPONENT Python)
 endmacro(AddPyLib)
 

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -44,6 +44,14 @@ else()
 		)
 endif()
 
+add_custom_command(
+    TARGET bufr_python
+    POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy_directory
+            ${CMAKE_CURRENT_SOURCE_DIR}/bufr
+            $<TARGET_FILE_DIR:bufr_python>
+    )
+
 install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/bufr
         DESTINATION ${CMAKE_INSTALL_LIBDIR}/${pyver}/site-packages
         COMPONENT Python

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -5,28 +5,21 @@ include(Targets)
 # Location of .pycodestyle for norm checking within IODA-converters
 set( BUFR_PYLINT_CFG_DIR ${CMAKE_CURRENT_SOURCE_DIR} )
 
-set(pyver python${Python3_VERSION_MAJOR}.${Python3_VERSION_MINOR})
-set(PYDIR ${pyver}/bufr)
-
-# Location of installed python iodaconv libraries
-set( PYIODACONV_BUILD_LIBDIR   ${CMAKE_BINARY_DIR}/lib/${PYDIR} )
-set( PYIODACONV_INSTALL_LIBDIR ${CMAKE_INSTALL_PREFIX}/lib/${PYDIR} )
-
-
-list (APPEND PYTHON_SRCS DataObjectFunctions.h
-												DataObjectFunctions.cpp
-												py_bufr.cpp
-												py_result_set.cpp
-												py_data_container.cpp
-												py_query_set.cpp
-												py_file.cpp
-												py_parser.cpp
-												py_data_cache.cpp
-											  py_encoder_description.cpp
-												py_netcdf_encoder.cpp
-												py_mpi.h
-												py_mpi.cpp
-												)
+list (APPEND PYTHON_SRCS
+  DataObjectFunctions.h
+  DataObjectFunctions.cpp
+  py_bufr.cpp
+  py_result_set.cpp
+  py_data_container.cpp
+  py_query_set.cpp
+  py_file.cpp
+  py_parser.cpp
+  py_data_cache.cpp
+  py_encoder_description.cpp
+  py_netcdf_encoder.cpp
+  py_mpi.h
+  py_mpi.cpp
+)
 
 # We cannot call ecbuild_add_library here since it conflicts with pybind11_add_module.
 pybind11_add_module(bufr_python ${PYTHON_SRCS})
@@ -51,13 +44,7 @@ else()
 		)
 endif()
 
-add_custom_command(TARGET bufr_python
-									 POST_BUILD
-									 COMMAND ${CMAKE_COMMAND} -E copy_directory
-	                 				 ${CMAKE_CURRENT_SOURCE_DIR}/bufr
-													 $<TARGET_FILE_DIR:bufr_python>)
-
 install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/bufr
-	      DESTINATION ${CMAKE_INSTALL_LIBDIR}/${pyver}
-			  COMPONENT Python
-	      FILES_MATCHING PATTERN "*.py")
+        DESTINATION ${CMAKE_INSTALL_LIBDIR}/${pyver}/site-packages
+        COMPONENT Python
+        FILES_MATCHING PATTERN "*.py")


### PR DESCRIPTION
The purpose of moving the install location is to be compatible with spack-stack. The issue comes up with the setting of PYTHONPATH in the lua module file for bufr-query. spack-stack insists on inserting the site-packages directory into the install directory despite the fact that the cmake config wasn't placing it there.

I couldn't figure out a simple way to tell spack-stack (or spack) to not insert the site-packages directory and ended up using a spack patch mechanism which applies the exact same changes as in this PR.

Using "lib/pythonX.Y/site-packages" appears to be a standard location for any custom packages (in regard to what is shipped with the OS) built on a platform, and in the context of the OS, the spack-stack built packages seem to me to qualify as "custom". 