### PR TITLE
Fixed version number for BUFR-query

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@
 ################################################################################
 
 cmake_minimum_required( VERSION 3.14 )
-project( bufr_query VERSION 2.8.0 LANGUAGES CXX Fortran)
+project( bufr_query VERSION 0.0.4 LANGUAGES CXX Fortran)
 
 ## Configuration
 find_package( ecbuild QUIET )


### PR DESCRIPTION
Forgot to update the version number for the bufr-query project to the correct value.

Fixes #30 
