### PR TITLE
Modifications to make the NetCDF CXX component private instead of public

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -131,7 +131,7 @@ target_link_libraries(bufr_query PUBLIC gsl::gsl-lite)
 target_link_libraries(bufr_query PUBLIC Eigen3::Eigen)
 target_link_libraries(bufr_query PUBLIC MPI::MPI_CXX)
 target_link_libraries(bufr_query PUBLIC bufr::bufr_4)
-target_link_libraries(bufr_query PUBLIC NetCDF::NetCDF_CXX)
+target_link_libraries(bufr_query PRIVATE  NetCDF::NetCDF_CXX)
 target_link_libraries(bufr_query PUBLIC eckit eckit_mpi)
 
 

--- a/core/include/bufr/DataObject.h
+++ b/core/include/bufr/DataObject.h
@@ -12,14 +12,11 @@
 #include <memory>
 #include <iostream>
 #include <vector>
-#include <netcdf>
 
 #include "eckit/mpi/Comm.h"
 
 #include "QueryParser.h"
 #include "Data.h"
-
-namespace nc = netCDF;
 
 
 namespace bufr {


### PR DESCRIPTION
This PR changes the NetCDF CXX component from public to private so that clients (eg, ioda) of bufr-query don't need to have the netcdf-cxx4 package available. In the ioda case, there is no use of the NetCDF C++ API in the ioda code, but the NetCDF CXX package was required since bufr-query exported it as such. Changing the CXX component to private fixes this issue.

Partially addresses jcsda-internal/ioda/issues/1375