### PR TITLE
Add -s -B flags and the capability of compare multiple output files for the same obs type

### DIFF
--- a/tools/build_scripts/bufr_comp.sh
+++ b/tools/build_scripts/bufr_comp.sh
@@ -22,7 +22,7 @@ rc="-1"
 case $file_type in
   netcdf)
     $cmd && \
-    nccmp testrun/$file_name testoutput/$file_name -d -m -g -f -S -T ${tol}
+    nccmp testrun/$file_name testoutput/$file_name -d -m -g -f -s -S -B -T ${tol}
     rc=${?}
     ;;
    odb)

--- a/tools/build_scripts/bufr_comp.sh
+++ b/tools/build_scripts/bufr_comp.sh
@@ -10,7 +10,7 @@ set -eu
 
 file_type=$1
 cmd=$2  
-file_names=($3)     # convert space-separated strings into an array
+file_name=($3)     # convert space-separated strings into an array
 tol=${4:-"0.0"}
 verbose=${5:-${VERBOSE:-"N"}}
 
@@ -24,10 +24,8 @@ echo "emily checking: U are using new bufr_comp.sh ....."
 case $file_type in
   netcdf)
     $cmd && \
-    nccmp testrun/$file_name testoutput/$file_name -d -m -g -f -s -S -B -T ${tol}
-    rc=${?}
-    for i in "${!file_names[@]}"; do
-        file_name=${file_names[$i]}
+    for i in "${!file_name[@]}"; do
+        file_name=${file_name[$i]}
         nccmp testrun/$file_name testoutput/$file_name -d -m -g -f -s -S -B -T ${tol}
         rc=${?}
         if [[ $rc -ne 0 ]]; then

--- a/tools/build_scripts/bufr_comp.sh
+++ b/tools/build_scripts/bufr_comp.sh
@@ -19,7 +19,6 @@ verbose=${5:-${VERBOSE:-"N"}}
    $verbose == [Tt][Rr][Uu][Ee] ]] && set -x
 
 rc="-1"
-echo "emily checking: U are using new bufr_comp.sh ....."
 
 case $file_type in
   netcdf)


### PR DESCRIPTION
This PR adds two features:
1. Add -s- and -B flags to nccmp

-s : report when files are the same
-B: Load entire variable to memory to reduce memory allocation runtime overhead

2. Add the capability of processing nccmp for multiple output files (e.g. from  npp and n20)  for the same obs type (e.g. atms)
    nccmp testrun/gdas.t00z.atms_npp.tm00.nc  testoutput/gdas.t00z.atms_npp.tm00.nc
    nccmp testrun/gdas.t00z.atms_n20.tm00.nc  testoutput/gdas.t00z.atms_n20.tm00.nc