### PR TITLE
Make downloading test data optional

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,6 +30,7 @@ find_package( gsl-lite REQUIRED HINTS $ENV{gsl_lite_DIR} )
 find_package( NetCDF REQUIRED COMPONENTS CXX)
 find_package( bufr 12.0.1 REQUIRED)
 
+
 # Python-finding settings
 set(Python3_FIND_REGISTRY "LAST")
 set(Python3_FIND_FRAMEWORK "LAST")
@@ -52,10 +53,7 @@ if (BUILD_PYTHON_BINDINGS)
 endif()
 
 add_subdirectory( tools )
-
-if (NOT SKIP_BUILD_BUFR_QUERY_TESTS)
-  add_subdirectory( test )
-endif()
+add_subdirectory( test )
 
 ## Tests
 ecbuild_add_test( TARGET ${PROJECT_NAME}_coding_norms

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,7 +30,6 @@ find_package( gsl-lite REQUIRED HINTS $ENV{gsl_lite_DIR} )
 find_package( NetCDF REQUIRED COMPONENTS CXX)
 find_package( bufr 12.0.1 REQUIRED)
 
-
 # Python-finding settings
 set(Python3_FIND_REGISTRY "LAST")
 set(Python3_FIND_FRAMEWORK "LAST")
@@ -53,7 +52,10 @@ if (BUILD_PYTHON_BINDINGS)
 endif()
 
 add_subdirectory( tools )
-add_subdirectory( test )
+
+if (NOT SKIP_BUILD_BUFR_QUERY_TESTS)
+  add_subdirectory( test )
+endif()
 
 ## Tests
 ecbuild_add_test( TARGET ${PROJECT_NAME}_coding_norms

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,43 +1,45 @@
 # (C) Copyright 2024 NOAA/NCEP/EMC.
 
-# Download the test data if we don't have it.
-# Code borrowed from NCEPLIB-bufr project...
+if(NOT SKIP_DOWNLOAD_TEST_DATA)
 
-set(DOWNLOAD_URL "https://ftp.emc.ncep.noaa.gov/static_files/public/bufr-query")
-set(FILE_COLLECTION "bufr_query-0.0.1.tgz")
+  # Download the test data if we don't have it.
+  # Code borrowed from NCEPLIB-bufr project...
 
-# Get the test data if we don't have it.
-if(NOT EXISTS "${CMAKE_CURRENT_BINARY_DIR}/${FILE_COLLECTION}")
-  message(STATUS "Downloading: " ${CMAKE_CURRENT_BINARY_DIR}/${FILE_COLLECTION})
-  file(DOWNLOAD
-    ${DOWNLOAD_URL}/${FILE_COLLECTION}
-    ${CMAKE_CURRENT_BINARY_DIR}/${FILE_COLLECTION}
-    SHOW_PROGRESS
-    STATUS download_status
-    INACTIVITY_TIMEOUT 30
-  )
+  set(DOWNLOAD_URL "https://ftp.emc.ncep.noaa.gov/static_files/public/bufr-query")
+  set(FILE_COLLECTION "bufr_query-0.0.1.tgz")
 
-  list(GET download_status 0 download_status_num)
+  # Get the test data if we don't have it.
+  if(NOT EXISTS "${CMAKE_CURRENT_BINARY_DIR}/${FILE_COLLECTION}")
+    message(STATUS "Downloading: " ${CMAKE_CURRENT_BINARY_DIR}/${FILE_COLLECTION})
+    file(DOWNLOAD
+      ${DOWNLOAD_URL}/${FILE_COLLECTION}
+      ${CMAKE_CURRENT_BINARY_DIR}/${FILE_COLLECTION}
+      SHOW_PROGRESS
+      STATUS download_status
+      INACTIVITY_TIMEOUT 30
+    )
 
-  if(NOT download_status_num EQUAL 0 OR NOT EXISTS ${CMAKE_CURRENT_BINARY_DIR}/${FILE_COLLECTION})
-    # Remove empty file if download doesn't complete
-    file(REMOVE ${CMAKE_CURRENT_BINARY_DIR}/${BUFR_TAR})
-    message(STATUS "Could not download test files, not building tests")
-    return()
+    list(GET download_status 0 download_status_num)
+
+    if(NOT download_status_num EQUAL 0 OR NOT EXISTS ${CMAKE_CURRENT_BINARY_DIR}/${FILE_COLLECTION})
+      # Remove empty file if download doesn't complete
+      file(REMOVE ${CMAKE_CURRENT_BINARY_DIR}/${BUFR_TAR})
+      message(STATUS "Could not download test files, not building tests")
+      return()
+    endif()
+
+    add_custom_target(get_bufr_test_data ALL DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/${FILE_COLLECTION})
+    add_custom_command(
+      TARGET get_bufr_test_data
+      POST_BUILD
+      COMMAND ${CMAKE_COMMAND} -E chdir ${CMAKE_CURRENT_BINARY_DIR} tar xzf ${FILE_COLLECTION}
+      COMMAND ${CMAKE_COMMAND} -E chdir ${CMAKE_CURRENT_BINARY_DIR} rm -rf testdata
+      COMMAND ${CMAKE_COMMAND} -E chdir ${CMAKE_CURRENT_BINARY_DIR} rm -rf testoutput
+      COMMAND ${CMAKE_COMMAND} -E chdir ${CMAKE_CURRENT_BINARY_DIR} mv remote_data/testdata testdata
+      COMMAND ${CMAKE_COMMAND} -E chdir ${CMAKE_CURRENT_BINARY_DIR} mv remote_data/testoutput testoutput
+      COMMAND ${CMAKE_COMMAND} -E chdir ${CMAKE_CURRENT_BINARY_DIR} rm -rf remote_data)
   endif()
-
-  add_custom_target(get_bufr_test_data ALL DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/${FILE_COLLECTION})
-  add_custom_command(
-    TARGET get_bufr_test_data
-    POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E chdir ${CMAKE_CURRENT_BINARY_DIR} tar xzf ${FILE_COLLECTION}
-    COMMAND ${CMAKE_COMMAND} -E chdir ${CMAKE_CURRENT_BINARY_DIR} rm -rf testdata
-    COMMAND ${CMAKE_COMMAND} -E chdir ${CMAKE_CURRENT_BINARY_DIR} rm -rf testoutput
-    COMMAND ${CMAKE_COMMAND} -E chdir ${CMAKE_CURRENT_BINARY_DIR} mv remote_data/testdata testdata
-    COMMAND ${CMAKE_COMMAND} -E chdir ${CMAKE_CURRENT_BINARY_DIR} mv remote_data/testoutput testoutput
-    COMMAND ${CMAKE_COMMAND} -E chdir ${CMAKE_CURRENT_BINARY_DIR} rm -rf remote_data)
 endif()
-
 
 # Function definitions
 


### PR DESCRIPTION
Closes #55 

This PR allows us to build on a compute note and skip downloading the test data if `SKIP_DOWNLOAD_TEST_DATA` is `ON`. I decided to still build the tests in case one wants to download the tarball (or cp/ln it) and run the tests and not have to re-run all of the build process