### PR TITLE
Fix type mismatch.

### DIFF
--- a/core/src/bufr/BufrReader/Exports/Variables/SensorScanPositionVariable.cpp
+++ b/core/src/bufr/BufrReader/Exports/Variables/SensorScanPositionVariable.cpp
@@ -59,7 +59,7 @@ namespace bufr {
 
         // Declare and initialize scanline array
         // scanline has the same dimension as fovn
-        std::vector<int> scanpos(fovnObj->size(), DataObject<float>::missingValue());
+        std::vector<int> scanpos(fovnObj->size(), DataObject<int>::missingValue());
 
         // Get field-of-view number
         std::vector<int> fovn(fovnObj->size(), DataObject<int>::missingValue());


### PR DESCRIPTION
Bug: Variable type mismatched
A missing value for an integer variable was assigned to a float.  