### PR TITLE
Feature/add range

### DIFF
--- a/core/include/bufr/encoders/Description.h
+++ b/core/include/bufr/encoders/Description.h
@@ -33,8 +33,8 @@ namespace encoders {
         std::string name;
         std::string source;
         std::vector<std::string> dimensions;
-        std::string longName;
         std::string units;
+        std::string longName;
         std::shared_ptr<std::string> coordinates;  // Optional
         std::shared_ptr<Range> range;  // Optional
         std::vector<size_t> chunks;  // Optional
@@ -135,6 +135,7 @@ namespace encoders {
                             const std::string& units,
                             const std::string& longName = "",
                             const std::string& coordinates = "",
+			    const std::vector<size_t>& range = {},
                             const std::vector<size_t>& chunks = {},
                             const int compressionLevel = 3);
 

--- a/core/src/encoders/Description.cpp
+++ b/core/src/encoders/Description.cpp
@@ -32,8 +32,8 @@ namespace
             const char* Source = "source";
             const char* LongName = "longName";
             const char* Units = "units";
-            const char* Range = "range";
             const char* Coords = "coordinates";
+            const char* Range = "range";
             const char* Chunks = "chunks";
             const char* CompressionLevel = "compressionLevel";
         }  // namespace Variable
@@ -326,6 +326,7 @@ namespace encoders {
                                      const std::string& units,
                                      const std::string& longName,
                                      const std::string& coordinates,
+				     const std::vector<size_t>& range,
                                      const std::vector<size_t>& chunks,
                                      const int compressionLevel)
     {
@@ -342,6 +343,19 @@ namespace encoders {
         if (!coordinates.empty())
         {
             variable.coordinates = std::make_shared<std::string>(coordinates);
+        }
+
+        if (!range.empty())
+        {
+            if (range.size() != 2)
+            {
+                throw eckit::BadParameter("Range is the wrong size.");
+            }
+
+            auto newRange = std::make_shared<Range>();
+            newRange->start = range[0];
+            newRange->end = range[1];
+            variable.range = newRange;
         }
 
         variable.compressionLevel = compressionLevel;

--- a/python/py_encoder_description.cpp
+++ b/python/py_encoder_description.cpp
@@ -52,6 +52,7 @@ void setupEncoderDescription(py::module& m)
         py::arg("units"),
         py::arg("longName")="",
         py::arg("coordinates")="",
+	py::arg("range")=std::vector<size_t>{},
         py::arg("chunks")=std::vector<size_t>{},
         py::arg("compressionLevel")=3,
           "Add a variable to the description.")
@@ -77,6 +78,12 @@ void setupEncoderDescription(py::module& m)
             coordinates = var_dict["coordinates"].cast<std::string>();
           }
 
+          auto range = std::vector<size_t>{};
+          if (var_dict.contains("range"))
+          {
+            range = var_dict["range"].cast<std::vector<size_t>>();
+          }
+
           auto chunks = std::vector<size_t>{};
           if (var_dict.contains("chunks"))
           {
@@ -94,6 +101,7 @@ void setupEncoderDescription(py::module& m)
                               units,
                               longName,
                               coordinates,
+			      range,
                               chunks,
                               compressionLevel);
         }


### PR DESCRIPTION
This PR adds the ability to add a range to newly generated variables in python scripts, using add_variable
This was tested on an adpsfc script and worked as intended.

For some consistency, there was two small changes in the order of some of the variables.

This solves issue #45 

Thanks again to @rmclaren for helping with this.