### PR TITLE
Enhancements to ObsBuilder add_main_functions

### DIFF
--- a/docs/uml/BUFR_ObsBuilder.puml
+++ b/docs/uml/BUFR_ObsBuilder.puml
@@ -16,14 +16,13 @@ class Logger
 
 abstract class ObsBuilder
 {
-  - input_path : str
-  - mapping_path : str
+  - mapping_path : dict
   - log : Logger
 
-  + create_obs_group(input_path, mapping_path, category, env)
-  + create_obs_file(input_path, mapping_path, type="netcdf", output_path)
   + make_obs(comm)
   # _make_description()
+  + create_obs_group(input_path, mapping_path, category, env)
+  + create_obs_file(input_path, mapping_path, type="netcdf", output_path)
 }
 
 class MarineObsBuilder

--- a/python/bufr/obs_builder/__init__.py
+++ b/python/bufr/obs_builder/__init__.py
@@ -1,5 +1,5 @@
 from .logger import Logger
 
+from .add_main_functions import add_main_functions
 from .obs_builder import ObsBuilder
 from .obs_builder import add_encoder_type
-from .obs_builder import add_main_functions

--- a/python/bufr/obs_builder/add_main_functions.py
+++ b/python/bufr/obs_builder/add_main_functions.py
@@ -1,0 +1,123 @@
+
+import os
+import inspect
+import functools
+
+def _create_module_func(cls, method_name, config=None):
+    """Create a module-level function that calls cls.method_name with the same signature."""
+    # Get the bound method and its signature
+    method = getattr(cls, method_name)
+    sig = inspect.signature(method)
+    # Remove 'self' from parameters for the new function
+    params = [param for name, param in sig.parameters.items() if name != 'self']
+    new_sig = inspect.Signature(params)
+
+    # Define a generic wrapper that calls the method on a new instance
+    def wrapper(*args, **kwargs):
+        # Call the original method on an instance of cls
+        if 'config' in inspect.signature(cls.__init__).parameters:
+            return getattr(cls(config=config), method_name)(*args, **kwargs)
+        else:
+            return getattr(cls(), method_name)(*args, **kwargs)
+
+    # Use functools.wraps to copy name, docstring, etc., from the original method
+    wrapper = functools.wraps(method)(wrapper)
+    # Assign the exact signature to the wrapper so it appears correct to inspect and help
+    wrapper.__signature__ = new_sig
+    return wrapper
+
+def add_main_functions(cls):
+    create_obs_group = _create_module_func(cls, 'create_obs_group')
+    create_obs_file = _create_module_func(cls, 'create_obs_file')
+
+    def make_obs_builder(config:dict=None):
+        if 'config' in inspect.signature(cls.__init__).parameters:
+            return cls(config=config) if config else cls()
+        else:
+            return cls()
+
+    def create_obs_file_from_config(config):
+        # Get parameters from configuration
+        data_format = config["data_format"]
+        data_type = config["data_type"]
+        cycle_type = config["cycle_type"]
+        dump_dir = config["dump_directory"]
+        cycle = config["cycle_datetime"]
+        ioda_dir = config["ioda_directory"]
+
+        # Make input path
+        yyyymmdd = cycle[0:8]
+        hh = cycle[8:10]
+        bufrfile = f"{cycle_type}.t{hh}z.{data_type}.tm{hh}.{data_format}"
+        input_path = os.path.join(dump_dir, f"{cycle_type}.{yyyymmdd}", str(hh), f"atmos", bufrfile)
+
+        # Make output path
+        iodafile = f"{cycle_type}.t{hh}z.{data_type}.tm00.nc"
+        output_path = os.path.join(ioda_dir, iodafile)
+
+        create_obs_file(input_path, output_path, config)
+
+    def default_main():
+        import sys
+        import time
+        import argparse
+        import yaml
+        from bufr import mpi
+        from bufr.obs_builder import Logger
+
+        logger = Logger(os.path.basename(__file__))
+
+        start_time = time.time()
+
+        mpi.App(sys.argv)
+        comm = mpi.Comm("world")
+
+        create_file_sig = inspect.signature(create_obs_file)
+
+        # Required input arguments
+        parser = argparse.ArgumentParser()
+
+        for param in create_file_sig.parameters.values():
+            if param.name == 'self':
+                continue
+            if param.default is param.empty:
+                parser.add_argument(f'--{param.name}', required=True)
+            else:
+                parser.add_argument(f'--{param.name}', default=param.default)
+
+        parser.add_argument(f'--config', required=False)
+        args = parser.parse_args()
+
+        if args.config:
+            with open(args.config, "r") as file:
+                config = yaml.safe_load(file)
+
+            create_obs_file_from_config(config)
+
+            if args.output or args.input:
+                logger.warning('Ignoring input and output arguments when using config.')
+        else:
+            if not args.input or not args.output:
+                logger.error('Both Input and output arguments are required.')
+                sys.exit(1)
+
+            create_args = {k: v for k, v in vars(args).items() if k in create_file_sig.parameters}
+            create_kwargs = {k: v for k, v in vars(args).items() if k not in create_file_sig.parameters}
+            create_kwargs.pop('config')
+
+            create_obs_file(**create_args, **create_kwargs)
+
+        end_time = time.time()
+        running_time = end_time - start_time
+        logger.info(f'Total running time: {running_time}')
+
+    caller_frame = inspect.stack()[1]
+    calling_module = inspect.getmodule(caller_frame.frame)
+    calling_module.make_obs_builder = make_obs_builder
+    calling_module.create_obs_group = create_obs_group
+    calling_module.create_obs_file = create_obs_file
+    calling_module.create_obs_file_from_config = create_obs_file_from_config
+    calling_module.default_main = default_main
+
+    if calling_module.__name__ == '__main__':
+        default_main()

--- a/python/bufr/obs_builder/add_main_functions.py
+++ b/python/bufr/obs_builder/add_main_functions.py
@@ -3,20 +3,27 @@ import os
 import inspect
 import functools
 
-def _create_module_func(cls, method_name, config=None):
+def _create_module_func(cls, method_name):
     """Create a module-level function that calls cls.method_name with the same signature."""
     # Get the bound method and its signature
     method = getattr(cls, method_name)
     sig = inspect.signature(method)
+
     # Remove 'self' from parameters for the new function
     params = [param for name, param in sig.parameters.items() if name != 'self']
+    # Add optional 'config' parameter to the parameters
+    params.append(inspect.Parameter('config',
+                                    inspect.Parameter.KEYWORD_ONLY,
+                                    default={}))
+
     new_sig = inspect.Signature(params)
 
     # Define a generic wrapper that calls the method on a new instance
     def wrapper(*args, **kwargs):
         # Call the original method on an instance of cls
         if 'config' in inspect.signature(cls.__init__).parameters:
-            return getattr(cls(config=config), method_name)(*args, **kwargs)
+            kwargs.pop('config', None)
+            return getattr(cls(config=kwargs['config']), method_name)(*args, **kwargs)
         else:
             return getattr(cls(), method_name)(*args, **kwargs)
 

--- a/python/bufr/obs_builder/add_main_functions.py
+++ b/python/bufr/obs_builder/add_main_functions.py
@@ -3,39 +3,7 @@ import os
 import inspect
 import functools
 
-def _create_module_func(cls, method_name):
-    """Create a module-level function that calls cls.method_name with the same signature."""
-    # Get the bound method and its signature
-    method = getattr(cls, method_name)
-    sig = inspect.signature(method)
-
-    # Remove 'self' from parameters for the new function
-    params = [param for name, param in sig.parameters.items() if name != 'self']
-    # Add optional 'config' parameter to the parameters
-    params.append(inspect.Parameter('config',
-                                    inspect.Parameter.KEYWORD_ONLY,
-                                    default={}))
-
-    new_sig = inspect.Signature(params)
-
-    # Define a generic wrapper that calls the method on a new instance
-    def wrapper(*args, **kwargs):
-        # Call the original method on an instance of cls
-        if 'config' in inspect.signature(cls.__init__).parameters:
-            kwargs.pop('config', None)
-            return getattr(cls(config=kwargs['config']), method_name)(*args, **kwargs)
-        else:
-            return getattr(cls(), method_name)(*args, **kwargs)
-
-    # Use functools.wraps to copy name, docstring, etc., from the original method
-    wrapper = functools.wraps(method)(wrapper)
-    # Assign the exact signature to the wrapper so it appears correct to inspect and help
-    wrapper.__signature__ = new_sig
-    return wrapper
-
-def add_main_functions(cls):
-    create_obs_group = _create_module_func(cls, 'create_obs_group')
-    create_obs_file = _create_module_func(cls, 'create_obs_file')
+def add_main_functions(cls, execute_main=True):
 
     def make_obs_builder(config:dict=None):
         if 'config' in inspect.signature(cls.__init__).parameters:
@@ -67,8 +35,8 @@ def add_main_functions(cls):
     def default_main():
         import sys
         import time
-        import argparse
         import yaml
+        import argparse
         from bufr import mpi
         from bufr.obs_builder import Logger
 
@@ -118,6 +86,34 @@ def add_main_functions(cls):
         running_time = end_time - start_time
         logger.info(f'Total running time: {running_time}')
 
+    def _create_module_func(cls, method_name):
+        """Create a module-level function that calls cls.method_name with the same signature."""
+        # Get the bound method and its signature
+        method = getattr(cls, method_name)
+        sig = inspect.signature(method)
+
+        # Remove 'self' from parameters for the new function
+        params = [param for name, param in sig.parameters.items() if name != 'self']
+        # Add optional 'config' parameter to the parameters
+        params.append(inspect.Parameter('config',
+                                        inspect.Parameter.KEYWORD_ONLY,
+                                        default={}))
+
+        new_sig = inspect.Signature(params)
+
+        # Define a generic wrapper that calls the method on a new instance
+        def wrapper(*args, **kwargs):
+            return getattr(make_obs_builder(kwargs.pop('config', {})), method_name)(*args, **kwargs)
+
+        # Use functools.wraps to copy name, docstring, etc., from the original method
+        wrapper = functools.wraps(method)(wrapper)
+        # Assign the exact signature to the wrapper so it appears correct to inspect and help
+        wrapper.__signature__ = new_sig
+        return wrapper
+
+    create_obs_group = _create_module_func(cls, 'create_obs_group')
+    create_obs_file = _create_module_func(cls, 'create_obs_file')
+
     caller_frame = inspect.stack()[1]
     calling_module = inspect.getmodule(caller_frame.frame)
     calling_module.make_obs_builder = make_obs_builder
@@ -126,5 +122,5 @@ def add_main_functions(cls):
     calling_module.create_obs_file_from_config = create_obs_file_from_config
     calling_module.default_main = default_main
 
-    if calling_module.__name__ == '__main__':
+    if calling_module.__name__ == '__main__' and execute_main:
         default_main()

--- a/python/bufr/obs_builder/add_main_functions.py
+++ b/python/bufr/obs_builder/add_main_functions.py
@@ -11,27 +11,6 @@ def add_main_functions(cls, execute_main=True):
         else:
             return cls()
 
-    def create_obs_file_from_config(config):
-        # Get parameters from configuration
-        data_format = config["data_format"]
-        data_type = config["data_type"]
-        cycle_type = config["cycle_type"]
-        dump_dir = config["dump_directory"]
-        cycle_datetime = config["cycle_datetime"]
-        ioda_dir = config["ioda_directory"]
-
-        # Make input path
-        yyyymmdd = cycle_datetime[0:8]
-        hh = cycle_datetime[8:10]
-        bufrfile = f"{cycle_datetime}-{cycle_type}.t{hh}z.{data_format}.tm00.bufr_d"
-        input_path = os.path.join(dump_dir, bufrfile)
-
-        # Make output path
-        iodafile = f"{cycle_type}.t{hh}z.{data_type}.tm00.nc"
-        output_path = os.path.join(ioda_dir, iodafile)
-
-        create_obs_file(input_path, output_path, config=config)
-
     def default_main():
         import sys
         import time
@@ -59,28 +38,12 @@ def add_main_functions(cls, execute_main=True):
                 parser.add_argument(f'--{param.name}', required=True)
             else:
                 parser.add_argument(f'--{param.name}', default=param.default)
-
-        parser.add_argument(f'--config', required=False)
         args = parser.parse_args()
 
-        if args.config:
-            with open(args.config, "r") as file:
-                config = yaml.safe_load(file)
+        create_args = {k: v for k, v in vars(args).items() if k in create_file_sig.parameters}
+        create_kwargs = {k: v for k, v in vars(args).items() if k not in create_file_sig.parameters}
 
-            create_obs_file_from_config(config)
-
-            if args.output or args.input:
-                logger.warning('Ignoring input and output arguments when using config.')
-        else:
-            if not args.input or not args.output:
-                logger.error('Both Input and output arguments are required.')
-                sys.exit(1)
-
-            create_args = {k: v for k, v in vars(args).items() if k in create_file_sig.parameters}
-            create_kwargs = {k: v for k, v in vars(args).items() if k not in create_file_sig.parameters}
-            create_kwargs.pop('config')
-
-            create_obs_file(**create_args, **create_kwargs)
+        create_obs_file(**create_args, **create_kwargs)
 
         end_time = time.time()
         running_time = end_time - start_time
@@ -119,7 +82,6 @@ def add_main_functions(cls, execute_main=True):
     calling_module.make_obs_builder = make_obs_builder
     calling_module.create_obs_group = create_obs_group
     calling_module.create_obs_file = create_obs_file
-    calling_module.create_obs_file_from_config = create_obs_file_from_config
     calling_module.default_main = default_main
 
     if calling_module.__name__ == '__main__' and execute_main:

--- a/python/bufr/obs_builder/obs_builder.py
+++ b/python/bufr/obs_builder/obs_builder.py
@@ -9,119 +9,11 @@ from ..encoders import netcdf, zarr
 from .logger import Logger
 
 
-
 FILE_ENCODER_DICT = {'netcdf': netcdf.Encoder,
                      'zarr': zarr.Encoder}
 
 def add_encoder_type(name, encoder):
     FILE_ENCODER_DICT[name] = encoder
-
-
-def add_main_functions(cls, uses_categories=False, uses_cache=False):
-    def make_obs_builder(config:dict=None):
-        if 'config' in inspect.signature(cls.__init__).parameters:
-            return cls(config=config) if config else cls()
-        else:
-            return cls()
-
-    # Create ObsGroup functions
-    def create_obs_group_w_cache(input_path, category, env, config:dict=None):
-        return make_obs_builder(config=config).create_obs_group_w_cache(input_path, category, env)
-
-    def create_obs_group_no_cache_cat(input_path, category, env, config:dict=None):
-        return make_obs_builder(config=config).create_obs_group_no_cache(input_path, env, category)
-
-    def create_obs_group_no_cache_no_cat(input_path, env, config:dict=None):
-        return make_obs_builder(config=config).create_obs_group_no_cache(input_path, env, '')
-
-    def create_obs_file(input_path, output_path, type='netcdf', append=False, config:dict=None):
-        make_obs_builder(config=config).create_obs_file(input_path, output_path, type, append)
-
-    def create_obs_file_from_config(config):
-        # Get parameters from configuration
-        data_format = config["data_format"]
-        data_type = config["data_type"]
-        cycle_type = config["cycle_type"]
-        dump_dir = config["dump_directory"]
-        cycle = config["cycle_datetime"]
-        ioda_dir = config["ioda_directory"]
-
-        # Make input path
-        yyyymmdd = cycle[0:8]
-        hh = cycle[8:10]
-        bufrfile = f"{cycle_type}.t{hh}z.{data_type}.tm{hh}.{data_format}"
-        input_path = os.path.join(dump_dir, f"{cycle_type}.{yyyymmdd}", str(hh), f"atmos", bufrfile)
-
-        # Make output path
-        iodafile = f"{cycle_type}.t{hh}z.{data_type}.tm00.nc"
-        output_path = os.path.join(ioda_dir, iodafile)
-
-        create_obs_file(input_path, output_path, config)
-
-    def default_main():
-        import sys
-        import time
-        import argparse
-        import yaml
-        from bufr import mpi
-        from bufr.obs_builder import Logger
-
-        logger = Logger(os.path.basename(__file__))
-
-        start_time = time.time()
-
-        mpi.App(sys.argv)
-        comm = mpi.Comm("world")
-
-        # Required input arguments
-        parser = argparse.ArgumentParser()
-        parser.add_argument('-i', '--input', type=str, help='Input BUFR')
-        parser.add_argument('-o', '--output', type=str, help='Output NetCDF')
-        parser.add_argument('-c', '--config', type=str, help='GDAS App style config')
-
-        args = parser.parse_args()
-
-        if args.config:
-            with open(args.config, "r") as file:
-                config = yaml.safe_load(file)
-
-            create_obs_file_from_config(config)
-
-            if args.output or args.input:
-                logger.warning('Ignoring input and output arguments when using config.')
-        else:
-            if not args.input or not args.output:
-                logger.error('Both Input and output arguments are required.')
-                sys.exit(1)
-
-            create_obs_file(args.input, args.output)
-
-        end_time = time.time()
-        running_time = end_time - start_time
-        logger.info(f'Total running time: {running_time}')
-
-    caller_frame = inspect.stack()[1]
-    calling_module = inspect.getmodule(caller_frame.frame)
-    calling_module.make_obs_builder = make_obs_builder
-
-    if uses_cache:
-        if uses_categories:
-            calling_module.create_obs_group = create_obs_group_w_cache
-        else:
-            assert False, 'Caching is only supported with categories'
-    else:
-        if uses_categories:
-            calling_module.create_obs_group = create_obs_group_no_cache_cat
-        else:
-            calling_module.create_obs_group = create_obs_group_no_cache_no_cat
-
-    calling_module.create_obs_file = create_obs_file
-    calling_module.create_obs_file_from_config = create_obs_file_from_config
-    calling_module.default_main = default_main
-
-    if calling_module.__name__ == '__main__':
-        default_main()
-
 
 class ObsBuilder:
     def __init__(self, mapping_path:Union[str, dict], config:dict=None, log_name:str='obs_builder'):
@@ -162,11 +54,43 @@ class ObsBuilder:
         return container
 
     def _make_description(self) -> bufr.encoders.Description:
-        assert len(self.map_dict) > 0, 'No mapping file provided, please override _make_description()'
+        if len(self.map_dict) != 1:
+            assert False, 'You must create a custom override for _make_description().'
 
         return bufr.encoders.Description(list(self.map_dict.values())[0])
 
-    def create_obs_group_w_cache(self, input, category, env):
+    def create_obs_file(self, input, output, type='netcdf', append=False):
+
+        comm = bufr.mpi.Comm("world")
+        self.log.comm = comm
+
+        container = self.make_obs(comm, input)
+        container.gather(comm)
+
+        # Encode the data
+        if comm.rank() == 0:
+            FILE_ENCODER_DICT[type](self.description).encode(container, output, append)
+
+        self.log.info(f'Return the encoded data')
+
+    def create_obs_group(self, input, env, category=''):
+        """
+        Create an observation group from the input data.
+
+        Args:
+            input (str): Path to the input data.
+            env (dict): Environment variables.
+            category (str): Category of the observation group.
+
+        Returns:
+            dict: Encoded data.
+        """
+        if category:
+            return self._create_obs_group_w_cache(input, category, env)
+        else:
+            return self._create_obs_group_no_cache(input, env)
+
+    def _create_obs_group_w_cache(self, input, category, env):
         from pyioda.ioda.Engines.Bufr import Encoder as iodaEncoder
         assert type(input) == str, 'Input was not a path str, please override create_obs_group'
 
@@ -212,7 +136,7 @@ class ObsBuilder:
         self.log.info(f'Return the encoded data for {category}')
         return data
 
-    def create_obs_group_no_cache(self, input, env, category=''):
+    def _create_obs_group_no_cache(self, input, env, category=''):
         from pyioda.ioda.Engines.Bufr import Encoder as iodaEncoder
         assert type(input) == str, 'Input was not a path str, please override create_obs_group'
 
@@ -231,17 +155,3 @@ class ObsBuilder:
             data = iodaEncoder(self.description).encode(container)[(category,)]
 
         return data
-
-    def create_obs_file(self, input, output_path, type='netcdf', append=False):
-
-        comm = bufr.mpi.Comm("world")
-        self.log.comm = comm
-
-        container = self.make_obs(comm, input)
-        container.gather(comm)
-
-        # Encode the data
-        if comm.rank() == 0:
-            FILE_ENCODER_DICT[type](self.description).encode(container, output_path, append)
-
-        self.log.info(f'Return the encoded data')

--- a/python/bufr/obs_builder/obs_builder.py
+++ b/python/bufr/obs_builder/obs_builder.py
@@ -16,7 +16,12 @@ def add_encoder_type(name, encoder):
     FILE_ENCODER_DICT[name] = encoder
 
 class ObsBuilder:
-    def __init__(self, mapping_path:Union[str, dict], config:dict=None, log_name:str='obs_builder'):
+    def __init__(self,
+                 mapping_path:Union[str, dict],
+                 config:dict=None,
+                 log_name:str='obs_builder',
+                 uses_categories:bool=False,
+                 uses_cache:bool=False):
         """
         ObsBuilder constructor
 
@@ -36,6 +41,8 @@ class ObsBuilder:
         self.log = Logger(log_name)
         self.config = config
         self.description = self._make_description()
+        self.uses_categories = uses_categories
+        self.uses_cache = uses_cache
 
     # Virtual Method
     def make_obs(self, comm, input : Union[str, dict]) -> bufr.DataContainer:
@@ -84,8 +91,11 @@ class ObsBuilder:
         Returns:
             dict: Encoded data.
         """
-        if category:
+
+        if self.uses_cache:
             return self._create_obs_group_w_cache(input, category, env)
+        elif self.uses_categories:
+            return self._create_obs_group_no_cache(input, env, category)
         else:
             return self._create_obs_group_no_cache(input, env)
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -93,6 +93,7 @@ list( APPEND test_input
   testinput/bufrtest_python_test.py
   testinput/bufrtest_python_mpi_test.py
   testinput/bufrtest_python_obsbuilder.py
+  testinput/bufrtest_python_obsbuilder_mod_sig.py
 )
 
 # create test directories and make links to the input files
@@ -570,6 +571,12 @@ if (${BUILD_PYTHON_BINDINGS})
                     TYPE    SCRIPT
                     COMMAND python3
                     ARGS    testinput/bufrtest_python_obsbuilder.py
+                    ENVIRONMENT PYTHONPATH=${CMAKE_BINARY_DIR}/lib/python${Python3_VERSION_MAJOR}.${Python3_VERSION_MINOR}/site-packages:$ENV{PYTHONPATH})
+
+  ecbuild_add_test( TARGET  test_bufr_python_obsbuilder_mod_signature
+                    TYPE    SCRIPT
+                    COMMAND python3
+                    ARGS    testinput/bufrtest_python_obsbuilder_mod_sig.py
                     ENVIRONMENT PYTHONPATH=${CMAKE_BINARY_DIR}/lib/python${Python3_VERSION_MAJOR}.${Python3_VERSION_MINOR}/site-packages:$ENV{PYTHONPATH})
 
 endif()

--- a/test/testinput/bufrtest_python_obsbuilder_mod_sig.py
+++ b/test/testinput/bufrtest_python_obsbuilder_mod_sig.py
@@ -1,0 +1,61 @@
+import os
+import sys
+import inspect
+import subprocess
+
+import bufr
+from bufr.obs_builder import ObsBuilder, add_main_functions
+
+def run_compare(input_path, comp_path):
+    result = subprocess.Popen(f'nccmp -d -m -g -f -S {input_path} {comp_path}', shell=True).wait()
+    assert result == 0, f"Comparison failed for {input_path} and {comp_path}."
+
+def map_path(map_file_name):
+    script_dir = os.path.dirname(os.path.abspath(__file__))
+    return os.path.join(script_dir, map_file_name)
+
+MAPPING_PATH = map_path('bufrtest_mhs_basic_mapping.yaml')
+
+class TestObsBuilder(ObsBuilder):
+    def __init__(self):
+        super().__init__(MAPPING_PATH)
+
+    def make_obs(self, comm, input):
+        # Custom implementation for testing
+        return super().make_obs(comm, input)
+
+    def create_obs_file(self, input1, input2, output):
+        # Custom implementation for testing
+        pass
+
+    def create_obs_group(self, input1, input2):
+        # Custom implementation for testing
+        pass
+
+add_main_functions(TestObsBuilder, execute_main=False)
+
+def test_obs_builder_interface():
+    module_functions = [member[1] for member in inspect.getmembers(__import__(__name__), inspect.isfunction)]
+
+    function_names = [func.__name__ for func in module_functions]
+
+    assert 'create_obs_file' in function_names, "create_obs_file function not found"
+    # assert 'create_obs_group' in function_names, "create_obs_group function not found"
+    assert 'default_main' in function_names, "default_main function not found"
+
+    # check the signature of the create_obs_file function
+    create_obs_file_sig = inspect.signature(create_obs_file)
+    assert 'input1' in create_obs_file_sig.parameters, "input1 parameter not found in create_obs_file signature"
+    assert 'input2' in create_obs_file_sig.parameters, "input2 parameter not found in create_obs_file signature"
+    assert 'output' in create_obs_file_sig.parameters, "output parameter not found in create_obs_file signature"
+    assert 'config' in create_obs_file_sig.parameters, "config parameter not found in create_obs_file signature"
+
+    # check the signature of the create_obs_group function
+    create_obs_group_sig = inspect.signature(create_obs_group)
+    assert 'input1' in create_obs_group_sig.parameters, "input1 parameter not found in create_obs_group signature"
+    assert 'input2' in create_obs_group_sig.parameters, "input2 parameter not found in create_obs_group signature"
+    assert 'config' in create_obs_group_sig.parameters, "config parameter not found in create_obs_group signature"
+
+
+if __name__ == '__main__':
+    test_obs_builder_interface()


### PR DESCRIPTION
Add main function adds the external functions to the ObsBuilder module. This pull request makes the determination of those functions signatures dependent on the function overrides for methods `create_obs_file` and `create_obs_group` in the ObsBuilder class. 

The function `create_obs_file_from_config`was removed as a module level function as the knowledge it contatined belongs too GDASApp and ObsForge.

Also the flags `uses_cache` and `uses_categories` were moved from `add_main_function` to the ObsBuilder objects themselves as these are really properties of the builder object.

