### PR TITLE
Move map_path and compute_wind_components to top layers of obs builder

### DIFF
--- a/python/bufr/obs_builder/__init__.py
+++ b/python/bufr/obs_builder/__init__.py
@@ -1,5 +1,6 @@
 from .logger import Logger
 
+from .map_path import map_path 
 from .add_main_functions import add_main_functions
 from .obs_builder import ObsBuilder
 from .obs_builder import add_encoder_type

--- a/python/bufr/obs_builder/map_path.py
+++ b/python/bufr/obs_builder/map_path.py
@@ -1,0 +1,27 @@
+
+import os
+
+def map_path(map_file_name, base_dir=None):
+    """
+    Construct the absolute path to a mapping file.
+
+    If `base_dir` is provided, the path will be relative to it.
+    Otherwise, the path is resolved relative to the current working directory.
+
+    :param map_file_name: Name of the mapping file (e.g., 'bufr_satwnd_ascat.yaml').
+    :type map_file_name: str
+    :param base_dir: Optional base directory to use instead of the current working directory.
+    :type base_dir: str or None
+
+    :returns: Absolute path to the mapping file.
+    :rtype: str
+
+    :raises FileNotFoundError: If the resolved file path does not exist.
+    """
+    root_dir = base_dir if base_dir is not None else os.getcwd()
+    path = os.path.join(root_dir, map_file_name)
+
+    if not os.path.exists(path):
+        raise FileNotFoundError(f"Mapping file not found: {path}")
+
+    return path

--- a/python/bufr/transforms/__init__.py
+++ b/python/bufr/transforms/__init__.py
@@ -1,0 +1,1 @@
+from .wind import compute_wind_components 

--- a/python/bufr/transforms/wind.py
+++ b/python/bufr/transforms/wind.py
@@ -1,0 +1,30 @@
+import numpy as np
+
+
+def compute_wind_components(speed, direction, in_degrees=True):
+    """
+    Convert wind speed and direction to u and v wind components.
+
+    :param speed: Wind speed in meters per second (m/s).
+    :type speed: float or array-like
+    :param direction: Wind direction (from which the wind is blowing), in degrees or radians.
+    :type direction: float or array-like
+    :param in_degrees: If True, `direction` is in degrees. If False, in radians.
+    :type in_degrees: bool
+
+    :returns: 
+        - u (float or ndarray): Zonal wind component (positive is eastward).
+        - v (float or ndarray): Meridional wind component (positive is northward).
+    :rtype: tuple of float or tuple of ndarray
+
+    :raises ValueError: If inputs are not broadcastable to the same shape.
+
+    .. note::
+       This function follows the meteorological convention where wind direction is
+       the direction **from which** the wind is blowing.
+    """
+    angle = np.deg2rad(direction) if in_degrees else direction
+    u = -speed * np.sin(angle)
+    v = -speed * np.cos(angle)
+
+    return u.astype(np.float32), v.astype(np.float32)


### PR DESCRIPTION
This PR implements the following:
- Move map_path to `bufr.obs_builder` package (handles current/executing directory or user-specified directory)
- Create new package for variable transform: `bufr.transforms.wind`
   Create wind.py and add compute_wind_components function

Usage:
```
from bufr.obs_builder import map_path
from bufr.transforms.wind import compute_wind_components
```

These enhancements should be tested with [SPOC PR #37 ](https://github.com/NOAA-EMC/spoc/pull/37)
