### PR TITLE
Move compute_solar_angles and get_default_nprocs to top levels f obs builder

### DIFF
--- a/python/bufr/obs_builder/__init__.py
+++ b/python/bufr/obs_builder/__init__.py
@@ -1,5 +1,6 @@
 from .logger import Logger
 
+from .get_default_nprocs import get_default_nprocs 
 from .map_path import map_path 
 from .add_main_functions import add_main_functions
 from .obs_builder import ObsBuilder

--- a/python/bufr/obs_builder/__init__.py
+++ b/python/bufr/obs_builder/__init__.py
@@ -1,5 +1,6 @@
 from .logger import Logger
 
+from .map_path import map_path 
 from .add_main_functions import add_main_functions
 from .obs_builder import ObsBuilder
 from .obs_builder import add_encoder_type

--- a/python/bufr/obs_builder/__init__.py
+++ b/python/bufr/obs_builder/__init__.py
@@ -1,6 +1,6 @@
 from .logger import Logger
 
-from .get_default_nprocs import get_default_nprocs 
+from .nprocs_per_task import nprocs_per_task
 from .map_path import map_path 
 from .add_main_functions import add_main_functions
 from .obs_builder import ObsBuilder

--- a/python/bufr/obs_builder/get_default_nprocs.py
+++ b/python/bufr/obs_builder/get_default_nprocs.py
@@ -1,0 +1,39 @@
+
+import os
+
+def get_default_nprocs(default=8):
+    """
+    Determine the number of processes to use.
+
+    The number of processes is determined from the environment variables
+    `CPUS_PER_TASK`, `SLURM_CPUS_PER_TASK`, or falls back to the default value.
+
+    Examples from command line:
+        1. Run with 1 slurm task and reserve 12 CPU cores for this one task.
+           In Python, this will spawn 12 worker processes via multiprocessing.Pool.
+           (SLURM_CPUS_PER_TASK = 12)
+           ``srun -n 1 --cpus_per_tasks=12 python bufr_ssmis.py``
+
+        2. Run without slurm and tell Python to spawn 12 worker processes.
+           ``export CPUS_PER_TASKS=12``
+           ``python bufr_ssmis.py``
+
+    :param default: Fallback default if nothing is found. Default is 8.
+    :type default: int
+
+    :return: Number of processes to use.
+    :rtype: int
+    """
+    env_nprocs = os.getenv("CPUS_PER_TASK")
+    slurm_nprocs = os.environ.get("SLURM_CPUS_PER_TASK")
+
+    print(f"CPUS_PER_TASK={env_nprocs}, SLURM_CPUS_PER_TASK={slurm_nprocs}")
+
+    try:
+        return int(env_nprocs or slurm_nprocs or default)
+    except ValueError:
+        print(f"[WARN] Invalid environment variable value. Falling back to default: {default}")
+        return default
+
+
+

--- a/python/bufr/obs_builder/map_path.py
+++ b/python/bufr/obs_builder/map_path.py
@@ -1,0 +1,27 @@
+
+import os
+
+def map_path(map_file_name, base_dir=None):
+    """
+    Construct the absolute path to a mapping file.
+
+    If `base_dir` is provided, the path will be relative to it.
+    Otherwise, the path is resolved relative to the current working directory.
+
+    :param map_file_name: Name of the mapping file (e.g., 'bufr_satwnd_ascat.yaml').
+    :type map_file_name: str
+    :param base_dir: Optional base directory to use instead of the current working directory.
+    :type base_dir: str or None
+
+    :returns: Absolute path to the mapping file.
+    :rtype: str
+
+    :raises FileNotFoundError: If the resolved file path does not exist.
+    """
+    root_dir = base_dir if base_dir is not None else os.getcwd()
+    path = os.path.join(root_dir, map_file_name)
+
+    if not os.path.exists(path):
+        raise FileNotFoundError(f"Mapping file not found: {path}")
+
+    return path

--- a/python/bufr/obs_builder/nprocs_per_task.py
+++ b/python/bufr/obs_builder/nprocs_per_task.py
@@ -1,7 +1,7 @@
 
 import os
 
-def get_default_nprocs(default=8):
+def nprocs_per_task(default=8):
     """
     Determine the number of processes to use.
 

--- a/python/bufr/transforms/__init__.py
+++ b/python/bufr/transforms/__init__.py
@@ -1,1 +1,2 @@
 from .wind import compute_wind_components 
+from .geometry import compute_solar_angles 

--- a/python/bufr/transforms/__init__.py
+++ b/python/bufr/transforms/__init__.py
@@ -1,0 +1,1 @@
+from .wind import compute_wind_components 

--- a/python/bufr/transforms/geometry.py
+++ b/python/bufr/transforms/geometry.py
@@ -1,0 +1,27 @@
+import os
+import pytz
+from pysolar.solar import get_altitude, get_azimuth
+from datetime import datetime, timezone
+
+def compute_solar_angles(lat, lon, unix_time):
+    """
+    Compute solar zenith and azimuth angles for a single point.
+
+    :param lat: Latitude in degrees.
+    :type lat: float
+    :param lon: Longitude in degrees.
+    :type lon: float
+    :param unix_time: Unix timestamp (seconds since 1970-01-01T00:00:00Z).
+    :type unix_time: int
+
+    :return: A tuple containing zenith angle and azimuth angle.
+    :rtype: tuple(float, float)
+    """
+
+    dt = datetime.fromtimestamp(int(unix_time), tz=timezone.utc)
+    altitude = get_altitude(lat, lon, dt)
+    azimuth = get_azimuth(lat, lon, dt)
+    zenith = 90.0 - altitude
+
+    return zenith, azimuth
+

--- a/python/bufr/transforms/wind.py
+++ b/python/bufr/transforms/wind.py
@@ -1,0 +1,30 @@
+import numpy as np
+
+
+def compute_wind_components(speed, direction, in_degrees=True):
+    """
+    Convert wind speed and direction to u and v wind components.
+
+    :param speed: Wind speed in meters per second (m/s).
+    :type speed: float or array-like
+    :param direction: Wind direction (from which the wind is blowing), in degrees or radians.
+    :type direction: float or array-like
+    :param in_degrees: If True, `direction` is in degrees. If False, in radians.
+    :type in_degrees: bool
+
+    :returns: 
+        - u (float or ndarray): Zonal wind component (positive is eastward).
+        - v (float or ndarray): Meridional wind component (positive is northward).
+    :rtype: tuple of float or tuple of ndarray
+
+    :raises ValueError: If inputs are not broadcastable to the same shape.
+
+    .. note::
+       This function follows the meteorological convention where wind direction is
+       the direction **from which** the wind is blowing.
+    """
+    angle = np.deg2rad(direction) if in_degrees else direction
+    u = -speed * np.sin(angle)
+    v = -speed * np.cos(angle)
+
+    return u.astype(np.float32), v.astype(np.float32)


### PR DESCRIPTION
This PR implements the following:

- Move `get_default_nprocs` to bufr.obs_builder package - get number of processes from either user or srun.  If none, falls back to default (nprocs=8)
- Create new package for variable transform: `bufr.transforms.geometry`
   Create geometry.py and add compute_solar_angles function
   
 Usage: 
 ```
from bufr.obs_builder import get_default_nprocs
from bufr.transforms.geometry import compute_solar_angles

```

These enhancements should be tested with [SPOC PR #36](https://github.com/NOAA-EMC/spoc/pull/36)