### PR TITLE
Create method to add dummy variables when category does not exist

### DIFF
--- a/python/bufr/obs_builder/__init__.py
+++ b/python/bufr/obs_builder/__init__.py
@@ -2,6 +2,9 @@ from .logger import Logger
 
 from .nprocs_per_task import nprocs_per_task
 from .map_path import map_path 
+from .add_dummy_variable import add_dummy_variable
+
 from .add_main_functions import add_main_functions
+
 from .obs_builder import ObsBuilder
 from .obs_builder import add_encoder_type

--- a/python/bufr/obs_builder/__init__.py
+++ b/python/bufr/obs_builder/__init__.py
@@ -3,8 +3,6 @@ from .logger import Logger
 from .nprocs_per_task import nprocs_per_task
 from .map_path import map_path 
 from .add_dummy_variable import add_dummy_variable
-
 from .add_main_functions import add_main_functions
-
 from .obs_builder import ObsBuilder
 from .obs_builder import add_encoder_type

--- a/python/bufr/obs_builder/add_dummy_variable.py
+++ b/python/bufr/obs_builder/add_dummy_variable.py
@@ -2,33 +2,29 @@ import numpy as np
 
 def add_dummy_variable(container, name, cat, base_var):
     """
-    Add a dummy variable to the observation container using a zero-length masked array.
+    Add a dummy variable to the observation container using an existing variable's structure.
 
-    This function is typically used when a sub-category exists but contains no valid data,
-    ensuring the variable still exists in the container with the correct structure.
+    This function attempts to retrieve the data and path structure of a base variable in the specified
+    sub-category. It then uses this information to insert a new variable (with the same structure and a
+    copy of the base data) under a different name. This is useful when ensuring consistent data output
+    even if a variable has no valid observations.
 
-    Parameters
-    ----------
-    container : object
-        The observation data container. Must support `get_paths(base_var, cat)` and `add(name, data, paths, cat)`.
+    :param container: Observation container object that provides access to data and path structure. 
+                      It must implement ``get_paths(var, cat)``, ``get(var, cat)``, and ``add(name, data, paths, cat)``.
+    :type container: object
+    :param name: Name of the new dummy variable to add.
+    :type name: str
+    :param cat: Sub-category key identifying a specific observation group (e.g., by sensor/platform).
+    :type cat: tuple
+    :param base_var: Name of an existing variable whose data and path structure will be used as a template.
+    :type base_var: str
+    :raises KeyError: If the base variable or its paths cannot be retrieved from the container.
+    :returns: None
+    :rtype: None
 
-    name : str
-        The name of the variable to add to the container.
+    :example:
 
-    cat : tuple
-        The sub-category identifier (usually a tuple of integers or strings).
-
-    base_var : str
-        The name of an existing variable in the container to base the path and dtype on.
-
-    Raises
-    ------
-    KeyError
-        If `base_var` is not found or paths cannot be resolved.
-
-    Returns
-    -------
-    None
+    >>> add_dummy_variable(container, 'windError', ('sensorA',), 'windSpeed')
     """
     try:
         paths = container.get_paths(base_var, cat)

--- a/python/bufr/obs_builder/add_dummy_variable.py
+++ b/python/bufr/obs_builder/add_dummy_variable.py
@@ -1,0 +1,39 @@
+import numpy as np
+
+def add_dummy_variable(container, name, cat, base_var):
+    """
+    Add a dummy variable to the observation container using a zero-length masked array.
+
+    This function is typically used when a sub-category exists but contains no valid data,
+    ensuring the variable still exists in the container with the correct structure.
+
+    Parameters
+    ----------
+    container : object
+        The observation data container. Must support `get_paths(base_var, cat)` and `add(name, data, paths, cat)`.
+
+    name : str
+        The name of the variable to add to the container.
+
+    cat : tuple
+        The sub-category identifier (usually a tuple of integers or strings).
+
+    base_var : str
+        The name of an existing variable in the container to base the path and dtype on.
+
+    Raises
+    ------
+    KeyError
+        If `base_var` is not found or paths cannot be resolved.
+
+    Returns
+    -------
+    None
+    """
+    try:
+        paths = container.get_paths(base_var, cat)
+        dummy = container.get(base_var, cat)
+        container.add(name, dummy, paths, cat)
+
+    except Exception as e:
+        raise KeyError(f"Failed to add dummy variable '{name}' using base '{base_var}' in category {cat}: {e}")


### PR DESCRIPTION
- Add a method to handle adding dummy variables to empty categories.
- The method (add_dummy_variable) is added to bufr.obs_builder

Usage example:
```
        satId = container.get('satelliteId', cat)
        if not satId.size: 
            self.log.warning(f'category {cat[0]} does not exist in input file')
            add_dummy_variable(container, 'obstype_uwind', cat, 'windComputationMethod')
            add_dummy_variable(container, 'obstype_vwind', cat, 'windComputationMethod')
            add_dummy_variable(container, 'windEastward', cat, 'windSpeed')
            add_dummy_variable(container, 'windNorthward', cat, 'windSpeed')
            add_dummy_variable(container, 'height', cat, 'pressure')
            add_dummy_variable(container, 'stationElevation', cat, 'pressure')
            return
```