### PR TITLE
Handle masked numpy arrays in DataContainer API

### DIFF
--- a/docs/python_api.rst
+++ b/docs/python_api.rst
@@ -76,6 +76,12 @@ Here is what the DataContainer looks like:
 
           Replace the variable with the given name.
 
+      .. note::
+
+          ``add`` and ``replace`` automatically detect ``numpy.ma.MaskedArray``
+          inputs and use the filled version of the array, so calling
+          ``filled()`` beforehand is unnecessary.
+
       .. method:: get_category_map()
 
           Get the map of categories.

--- a/python/py_data_container.cpp
+++ b/python/py_data_container.cpp
@@ -66,7 +66,14 @@ void setupDataContainer(py::module& m)
             paths[pathIdx] = QueryParser::parse(dimPaths[pathIdx])[0];
           }
 
-          auto dataObj = bufr::makeObject(fieldName, pyData);
+          py::array dataArray = pyData;
+          py::module numpyModule = py::module::import("numpy");
+          if (py::isinstance(pyData, numpyModule.attr("ma").attr("MaskedArray")))
+          {
+            dataArray = pyData.attr("filled")().cast<py::array>();
+          }
+
+          auto dataObj = bufr::makeObject(fieldName, dataArray);
           dataObj->setDimPaths(paths);
           self.add(fieldName, dataObj, categoryId);
         },
@@ -115,7 +122,14 @@ void setupDataContainer(py::module& m)
             }
           }
 
-          auto dataObj = bufr::makeObject(fieldName, pyData);
+          py::array dataArray = pyData;
+          py::module numpyModule = py::module::import("numpy");
+          if (py::isinstance(pyData, numpyModule.attr("ma").attr("MaskedArray")))
+          {
+            dataArray = pyData.attr("filled")().cast<py::array>();
+          }
+
+          auto dataObj = bufr::makeObject(fieldName, dataArray);
           dataObj->setDimPaths(data->getDimPaths());
           self.set(dataObj, fieldName, categoryId);
         },

--- a/test/testinput/bufrtest_python_test.py
+++ b/test/testinput/bufrtest_python_test.py
@@ -302,6 +302,17 @@ def test_highlevel_apply_mask():
     assert np.all(container.get('d0') == np.array([0, 3, 4, 7, 9]))
     assert np.all(container.get('d4') == np.array([0, 3, 4, 7, 9]))
 
+def test_add_replace_masked_array():
+    container = bufr.DataContainer()
+
+    arr = np.ma.array([1, 2, 3], mask=[False, True, False], fill_value=-99)
+    container.add('masked', arr, ['*'])
+    assert np.all(container.get('masked') == np.array([1, -99, 3]))
+
+    arr2 = np.ma.array([4, 5, 6], mask=[True, False, False], fill_value=-1)
+    container.replace('masked', arr2)
+    assert np.all(container.get('masked') == np.array([-1, 5, 6]))
+
 def test_zarr_encoder():
     DATA_PATH = 'testdata/gdas.t18z.1bmhs.tm00.bufr_d'
     YAML_PATH = 'testinput/bufrtest_mhs_basic_mapping.yaml'
@@ -327,6 +338,7 @@ if __name__ == '__main__':
     test_highlevel_cache()
     test_highlevel_append()
     test_highlevel_apply_mask()
+    test_add_replace_masked_array()
 
     # Test Encoders
     test_zarr_encoder()


### PR DESCRIPTION
## Summary
- automatically fill masked arrays in DataContainer `add` and `replace`
- document masked array handling in the Python API
- add regression test for masked array behavior

## Testing
- `ctest -j4 --output-on-failure` *(fails: No tests were found)*
- `python3 -m pip install numpy` *(fails: cannot connect to proxy)*