### PR TITLE
update test data tarball from version 0.0.1 to 0.0.2

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -6,7 +6,7 @@ if(NOT SKIP_DOWNLOAD_TEST_DATA)
   # Code borrowed from NCEPLIB-bufr project...
 
   set(DOWNLOAD_URL "https://ftp.emc.ncep.noaa.gov/static_files/public/bufr-query")
-  set(FILE_COLLECTION "bufr_query-0.0.1.tgz")
+  set(FILE_COLLECTION "bufr_query-0.0.2.tgz")
 
   # Get the test data if we don't have it.
   if(NOT EXISTS "${CMAKE_CURRENT_BINARY_DIR}/${FILE_COLLECTION}")


### PR DESCRIPTION
This PR updates the following
- Update test data reference for IASI.  
   (There was a bug fix for the IASI scan angle calculation, so the test reference needs to be updated.)
- Create test data tarball version 0.0.2

The test_bufr_mtiasi test passed with the updated reference.  