### PR TITLE
Make units an optional entry for description

### DIFF
--- a/python/py_encoder_description.cpp
+++ b/python/py_encoder_description.cpp
@@ -63,13 +63,18 @@ void setupEncoderDescription(py::module& m)
           // Required parameters
           auto name = var_dict["name"].cast<std::string>();
           auto source = var_dict["source"].cast<std::string>();
-          auto units = var_dict["units"].cast<std::string>();
 
           // Optional parameters
           std::string longName;
           if (var_dict.contains("longName"))
           {
             longName = var_dict["longName"].cast<std::string>();
+          }
+
+          std::string units;
+          if (var_dict.contains("units"))
+          {
+            units = var_dict["units"].cast<std::string>();
           }
 
           std::string coordinates;


### PR DESCRIPTION
In IODA convention (see definition in [ObsSpace.yaml](https://github.com/JCSDA-internal/ioda/blob/develop/share/ioda/yaml/validation/ObsSpace.yaml), the units are optional input.

For the enumerated data type, users do not need to specify units.
  