### PR TITLE
Dim name wrong when no data.

### DIFF
--- a/core/src/encoders/EncoderBase.cpp
+++ b/core/src/encoders/EncoderBase.cpp
@@ -187,6 +187,13 @@ namespace encoders {
 
         std::cout << warningStr.str() << std::endl;
 
+        // Instead of skipping, add the dimension with size 0 and correct name
+        auto newDim = std::make_shared<EncoderDimension>(
+          std::make_shared<DimensionData<int>>(descDim.name, 0),
+          descDim,
+          paths);
+        dims.push_back(newDim);
+        
         continue;
       }
 


### PR DESCRIPTION
Fixes issue where the dim name was wrong (default value) when there was no data, should be the name assigned in "dimensions" export section of YAML file.

Fixes Issue: #54.