### PR TITLE
Add missing value helper for numpy

### DIFF
--- a/docs/python_api.rst
+++ b/docs/python_api.rst
@@ -267,6 +267,20 @@ Example:
       return dataset
 
 
+Helper Functions
+----------------
+
+When creating new ``numpy.ma.MaskedArray`` objects you can obtain the
+appropriate missing value using :func:`get_missing_value`.
+
+.. code-block:: python
+
+   import bufr
+   import numpy as np
+
+   mv = bufr.get_missing_value(np.int64)
+
+
 
 Low Level API
 -------------

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -18,6 +18,7 @@ list (APPEND PYTHON_SRCS
   py_encoder_base.cpp
   py_encoder_description.cpp
   py_netcdf_encoder.cpp
+  py_helpers.cpp
   py_mpi.h
   py_mpi.cpp
 )

--- a/python/py_bufr.cpp
+++ b/python/py_bufr.cpp
@@ -19,6 +19,7 @@ void setupNetcdfEncoder(py::module& m);
 void setupDataContainer(py::module& m);
 void setupDataCache(py::module& m);
 void setupMpi(py::module& m);
+void setupHelpers(py::module& m);
 
 PYBIND11_MODULE(bufr_python, m)
 {
@@ -30,6 +31,7 @@ PYBIND11_MODULE(bufr_python, m)
   setupResultSet(m);
   setupParser(m);
   setupDataCache(m);
+  setupHelpers(m);
 
   auto mpi_m = m.def_submodule("mpi", "MPI bindings");
   setupMpi(mpi_m);

--- a/python/py_helpers.cpp
+++ b/python/py_helpers.cpp
@@ -1,0 +1,40 @@
+#include <pybind11/pybind11.h>
+#include <pybind11/numpy.h>
+#include <regex>
+
+#include "bufr/DataObject.h"
+
+namespace py = pybind11;
+
+namespace bufr {
+
+static const std::regex strRegex("[|\\<\\>]?[US]\\d*");
+
+// Return the missing value constant for the provided numpy dtype.
+py::object getMissingValue(const py::object& dtypeObj) {
+    py::dtype dt = py::dtype::from_args(dtypeObj);
+    std::string dtypeStr = py::cast<std::string>(py::str(dt));
+    std::cmatch m;
+
+    if (dt.is(py::dtype::of<int64_t>())) {
+        return py::int_(DataObject<int64_t>::missingValue());
+    } else if (dt.is(py::dtype::of<int>())) {
+        return py::int_(DataObject<int>::missingValue());
+    } else if (dt.is(py::dtype::of<double>())) {
+        return py::float_(DataObject<double>::missingValue());
+    } else if (dt.is(py::dtype::of<float>())) {
+        return py::float_(DataObject<float>::missingValue());
+    } else if (dtypeStr == "object" || std::regex_match(dtypeStr.c_str(), m, strRegex)) {
+        return py::str(DataObject<std::string>::missingValue());
+    }
+
+    throw std::runtime_error("Unsupported dtype for get_missing_value");
+}
+
+void setupHelpers(py::module& m) {
+    m.def("get_missing_value", &getMissingValue,
+          py::arg("dtype"),
+          "Return the missing value constant for the given numpy dtype.");
+}
+
+} // namespace bufr

--- a/python/py_helpers.cpp
+++ b/python/py_helpers.cpp
@@ -6,8 +6,6 @@
 
 namespace py = pybind11;
 
-namespace bufr {
-
 static const std::regex strRegex("[|\\<\\>]?[US]\\d*");
 
 // Return the missing value constant for the provided numpy dtype.
@@ -17,15 +15,15 @@ py::object getMissingValue(const py::object& dtypeObj) {
     std::cmatch m;
 
     if (dt.is(py::dtype::of<int64_t>())) {
-        return py::int_(DataObject<int64_t>::missingValue());
+        return py::int_(bufr::DataObject<int64_t>::missingValue());
     } else if (dt.is(py::dtype::of<int>())) {
-        return py::int_(DataObject<int>::missingValue());
+        return py::int_(bufr::DataObject<int>::missingValue());
     } else if (dt.is(py::dtype::of<double>())) {
-        return py::float_(DataObject<double>::missingValue());
+        return py::float_(bufr::DataObject<double>::missingValue());
     } else if (dt.is(py::dtype::of<float>())) {
-        return py::float_(DataObject<float>::missingValue());
+        return py::float_(bufr::DataObject<float>::missingValue());
     } else if (dtypeStr == "object" || std::regex_match(dtypeStr.c_str(), m, strRegex)) {
-        return py::str(DataObject<std::string>::missingValue());
+        return py::str(bufr::DataObject<std::string>::missingValue());
     }
 
     throw std::runtime_error("Unsupported dtype for get_missing_value");
@@ -36,5 +34,3 @@ void setupHelpers(py::module& m) {
           py::arg("dtype"),
           "Return the missing value constant for the given numpy dtype.");
 }
-
-} // namespace bufr

--- a/test/testinput/bufrtest_python_test.py
+++ b/test/testinput/bufrtest_python_test.py
@@ -313,6 +313,14 @@ def test_add_replace_masked_array():
     assert np.all(container.get('masked') == np.array([-1, 5, 6]))
 
 
+def test_get_missing_value():
+    assert bufr.get_missing_value(np.int32) == np.iinfo(np.int32).max
+    assert bufr.get_missing_value(np.int64) == np.iinfo(np.int64).max
+    assert bufr.get_missing_value(np.float32) == np.finfo(np.float32).max
+    assert bufr.get_missing_value(np.float64) == np.finfo(np.float64).max
+    assert bufr.get_missing_value(np.dtype('O')) == ""
+
+
 if __name__ == '__main__':
     # Low level interface tests
     test_basic_query()
@@ -329,3 +337,4 @@ if __name__ == '__main__':
     test_highlevel_append()
     test_highlevel_apply_mask()
     test_add_replace_masked_array()
+    test_get_missing_value()


### PR DESCRIPTION
## Summary
- provide helper for retrieving missing-value constants for numpy types
- expose helper via the Python module
- document usage in the Python API docs

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'bufr')*