### PR TITLE
Modify compute_solar_angles to use pvlib

### DIFF
--- a/python/bufr/transforms/geometry.py
+++ b/python/bufr/transforms/geometry.py
@@ -20,7 +20,13 @@ def compute_solar_angles(latitudes, longitudes, unix_times):
     :rtype: tuple(numpy.ndarray, numpy.ndarray)
     """
 
-    assert len(latitudes) == len(longitudes) == len(unix_times), "Input arrays must be the same length"
+    if not (latitudes.shape == longitudes.shape == unix_times.shape):
+        raise ValueError(
+            "Input arrays must all have the same shape. "
+            f"Got latitudes.shape={latitudes.shape}, "
+            f"longitudes.shape={longitudes.shape}, "
+            f"unix_times.shape={unix_times.shape}."
+        )
 
     times = pd.to_datetime(unix_times, unit='s', utc=True)
     solpos = get_solarposition(times, latitudes, longitudes)

--- a/python/bufr/transforms/geometry.py
+++ b/python/bufr/transforms/geometry.py
@@ -15,8 +15,6 @@ def compute_solar_angles(latitudes, longitudes, unix_times):
     :type longitudes: numpy.ndarray
     :param unix_times: Array of Unix timestamps (seconds since 1970-01-01T00:00:00Z).
     :type unix_times: numpy.ndarray
-    :param nprocs: Number of processes to use. Defaults to the number of CPU cores.
-    :type nprocs: int, optional
 
     :return: Two arrays: zenith angles and azimuth angles.
     :rtype: tuple(numpy.ndarray, numpy.ndarray)

--- a/python/bufr/transforms/geometry.py
+++ b/python/bufr/transforms/geometry.py
@@ -1,27 +1,33 @@
 import os
-import pytz
-from pysolar.solar import get_altitude, get_azimuth
-from datetime import datetime, timezone
+import numpy as np 
+import pandas as pd
+from pvlib.solarposition import get_solarposition
+from datetime import datetime
 
-def compute_solar_angles(lat, lon, unix_time):
+
+def compute_solar_angles(latitudes, longitudes, unix_times):
     """
-    Compute solar zenith and azimuth angles for a single point.
+    Compute solar zenith and azimuth angles in parallel using multiprocessing.
 
-    :param lat: Latitude in degrees.
-    :type lat: float
-    :param lon: Longitude in degrees.
-    :type lon: float
-    :param unix_time: Unix timestamp (seconds since 1970-01-01T00:00:00Z).
-    :type unix_time: int
+    :param latitudes: Array of latitudes in degrees.
+    :type latitudes: numpy.ndarray
+    :param longitudes: Array of longitudes in degrees.
+    :type longitudes: numpy.ndarray
+    :param unix_times: Array of Unix timestamps (seconds since 1970-01-01T00:00:00Z).
+    :type unix_times: numpy.ndarray
+    :param nprocs: Number of processes to use. Defaults to the number of CPU cores.
+    :type nprocs: int, optional
 
-    :return: A tuple containing zenith angle and azimuth angle.
-    :rtype: tuple(float, float)
+    :return: Two arrays: zenith angles and azimuth angles.
+    :rtype: tuple(numpy.ndarray, numpy.ndarray)
     """
 
-    dt = datetime.fromtimestamp(int(unix_time), tz=timezone.utc)
-    altitude = get_altitude(lat, lon, dt)
-    azimuth = get_azimuth(lat, lon, dt)
-    zenith = 90.0 - altitude
+    assert len(latitudes) == len(longitudes) == len(unix_times), "Input arrays must be the same length"
 
-    return zenith, azimuth
+    times = pd.to_datetime(unix_times, unit='s', utc=True)
+    solpos = get_solarposition(times, latitudes, longitudes)
+    zenith_angles = solpos['apparent_zenith'].values
+    azimuth_angles = solpos['azimuth'].values
+
+    return zenith_angles.astype(np.float32), azimuth_angles.astype(np.float32)
 


### PR DESCRIPTION
The current compute_solar_angles use `pysolar` which does not support vectorized computation.  So, we need to launch multiple processors for solar angle calculation

This PR modifies the compute_solar_angles to use `pvlib`, which supports vectorized computation.  