### PR TITLE
Add MPI barrier to Python bindings

### DIFF
--- a/docs/python_api.rst
+++ b/docs/python_api.rst
@@ -209,6 +209,7 @@ to make this easy. Please see the following example:
       comm = bufr.mpi.Comm("world")  # Get the MPI communicator
       container = bufr.Parser(DATA_PATH, YAML_PATH).parse(comm)  # Parse the BUFR file with mpi
       container.gather(comm)  # (OPTIONAL) Gather the DataContainer data from all the ranks
+      comm.barrier()          # Synchronize all ranks before continuing
 
       if comm.rank() == 0:
           netcdf.Encoder(YAML_PATH).encode(container, OUTPUT_PATH) # Encode the DataContainer object

--- a/python/py_mpi.cpp
+++ b/python/py_mpi.cpp
@@ -46,5 +46,6 @@ void setupMpi(py::module& m)
     .def(py::init<const std::string&>())
     .def("name", &bufr::mpi::Comm::name)
     .def("rank", &bufr::mpi::Comm::rank)
-    .def("size", &bufr::mpi::Comm::size);
+    .def("size", &bufr::mpi::Comm::size)
+    .def("barrier", &bufr::mpi::Comm::barrier);
 }

--- a/python/py_mpi.h
+++ b/python/py_mpi.h
@@ -16,6 +16,7 @@ namespace mpi {
     eckit::mpi::Comm& getComm() { return comm_; }
     int rank() { return comm_.rank(); }
     int size() { return comm_.size(); }
+    void barrier() { comm_.barrier(); }
 
   private:
     eckit::mpi::Comm& comm_;


### PR DESCRIPTION
## Summary
- expose `barrier` in the MPI python binding
- document MPI barrier use

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'bufr')*