### PR TITLE
Introduce custom exceptions

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -23,8 +23,9 @@ list(APPEND BUFR_PUBLIC
 	include/bufr/QueryParser.h
 	include/bufr/ResultSet.h
 	include/bufr/Tokenizer.h
-	include/bufr/SubsetTable.h
-	include/bufr/Data.h
+        include/bufr/SubsetTable.h
+        include/bufr/Data.h
+        include/bufr/Exceptions.h
 )
 
 list (APPEND ENCODERS_PUBLIC
@@ -34,12 +35,12 @@ list (APPEND ENCODERS_PUBLIC
 )
 
 list(APPEND BUFR_PRIVATE
-	src/bufr/ObjectFactory.h
-	src/bufr/DataContainer.cpp
-	src/bufr/DataObject.cpp
-	src/bufr/DataObjectBuilder.h
-	src/bufr/Log.h
-	src/bufr/BufrReader/BufrDescription.cpp
+        src/bufr/ObjectFactory.h
+        src/bufr/DataContainer.cpp
+        src/bufr/DataObject.cpp
+        src/bufr/DataObjectBuilder.h
+        src/bufr/Log.h
+        src/bufr/BufrReader/BufrDescription.cpp
 	src/bufr/BufrReader/BufrParser.cpp
 	src/bufr/BufrReader/Exports/Export.cpp
 	src/bufr/BufrReader/Exports/Filters/BoundingFilter.h

--- a/core/include/bufr/Exceptions.h
+++ b/core/include/bufr/Exceptions.h
@@ -1,0 +1,31 @@
+// (C) Copyright 2024 NOAA/NWS/NCEP/EMC
+
+#pragma once
+
+#include <stdexcept>
+#include <string>
+
+namespace bufr {
+
+class Exception : public std::runtime_error {
+ public:
+  explicit Exception(const std::string& what) : std::runtime_error(what) {}
+};
+
+class BadParameter : public Exception {
+ public:
+  explicit BadParameter(const std::string& what) : Exception(what) {}
+};
+
+class BadValue : public Exception {
+ public:
+  explicit BadValue(const std::string& what) : Exception(what) {}
+};
+
+class MissingData : public Exception {
+ public:
+  explicit MissingData(const std::string& what) : Exception(what) {}
+};
+
+}  // namespace bufr
+


### PR DESCRIPTION
## Summary
- add new header for bufr-specific exceptions in core
- list new header in build configuration

## Testing
- `cmake ..` *(fails: No CMAKE_Fortran_COMPILER)*

------
https://chatgpt.com/codex/tasks/task_e_683e1859ea848325910542d1fb0a87a5