### PR TITLE
Switch to custom BUFR exceptions

### DIFF
--- a/core/include/bufr/DataCache.h
+++ b/core/include/bufr/DataCache.h
@@ -11,6 +11,7 @@
 #include <string>
 
 #include "bufr/DataContainer.h"
+#include "bufr/Exceptions.h"
 
 #pragma once
 
@@ -57,7 +58,7 @@ namespace bufr {
 
           if (cache.find(key) == cache.end())
           {
-            throw eckit::BadParameter("DataCache::get: No cache entry for key " + key);
+            throw BadParameter("DataCache::get: No cache entry for key " + key);
           }
 
           return cache[key].data;
@@ -98,7 +99,7 @@ namespace bufr {
 
           if (cache.find(key) == cache.end())
           {
-            throw eckit::BadParameter("DataCache::markFinished: No cache entry for key " + key);
+            throw BadParameter("DataCache::markFinished: No cache entry for key " + key);
           }
 
           if (std::find(cache[key].cachedCategories.begin(),

--- a/core/include/bufr/DataObject.h
+++ b/core/include/bufr/DataObject.h
@@ -18,6 +18,7 @@
 
 #include "QueryParser.h"
 #include "Data.h"
+#include "bufr/Exceptions.h"
 
 
 namespace bufr {
@@ -89,7 +90,7 @@ namespace bufr {
             std::ostringstream str;
             str << "Cannot write data of type " << typeid(T).name() << " with writer of type ";
             str << typeid(writer).name();
-            throw eckit::BadParameter(str.str());
+            throw BadParameter(str.str());
         }
     }
 
@@ -375,7 +376,7 @@ namespace bufr {
           std::ostringstream str;
           str << "Multiplying integer field \"" << fieldName_ << "\" with a non-integer is ";
           str << "illegal. Please convert it to a float or double.";
-          throw eckit::BadParameter(str.str());
+          throw BadParameter(str.str());
         }
       }
 
@@ -418,7 +419,7 @@ namespace bufr {
         {
           std::ostringstream str;
           str << "Can not make numerical field from string data.";
-          throw eckit::BadParameter(str.str());
+          throw BadParameter(str.str());
         }
         else
         {
@@ -456,7 +457,7 @@ namespace bufr {
           std::ostringstream str;
           str << "Can not write data of type " << typeid(T).name() << " with writer of type ";
           str << typeid(writer).name();
-          throw eckit::BadParameter(str.str());
+          throw BadParameter(str.str());
         }
       }
 
@@ -705,7 +706,7 @@ namespace bufr {
         {
           std::ostringstream str;
           str << "Supplied mask does not match the number of rows in the data object.";
-          throw eckit::BadParameter(str.str());
+          throw BadParameter(str.str());
         }
 
         const int newNumRows = std::accumulate(mask.begin(), mask.end(), 0, std::plus());
@@ -742,7 +743,7 @@ namespace bufr {
         {
           std::ostringstream str;
           str << "Cannot append data of type " << typeid(data).name();
-          throw eckit::BadParameter(str.str());
+          throw BadParameter(str.str());
         }
 
         dims_[0] += other->dims_[0];
@@ -752,7 +753,7 @@ namespace bufr {
           {
             std::ostringstream str;
             str << "Cannot append data with different dimensions.";
-            throw eckit::BadParameter(str.str());
+            throw BadParameter(str.str());
           }
         }
         data_.insert(data_.end(), other->data_.begin(), other->data_.end());
@@ -786,7 +787,7 @@ namespace bufr {
             std::stringstream errStr;
             errStr << "Dimension " << name << " has an invalid source field. ";
             errStr << "The values do not repeat in each sequence.";
-            throw eckit::BadParameter(errStr.str());
+            throw BadParameter(errStr.str());
           }
         }
 
@@ -882,14 +883,14 @@ namespace bufr {
       /// \return Integer data.
       int getAsInt(const Location& loc) const final
       {
-        throw eckit::BadParameter("Cannot convert string to int");
+        throw BadParameter("Cannot convert string to int");
       };
 
       /// \brief Get the data at the location as an float.
       /// \return Float data.
       float getAsFloat(const Location& loc) const final
       {
-        throw eckit::BadParameter("Cannot convert string to float");
+        throw BadParameter("Cannot convert string to float");
       };
 
       /// \brief Get the data at the Location as an string.
@@ -910,14 +911,14 @@ namespace bufr {
       /// \return Int data.
       int getAsInt(size_t idx) const final
       {
-        throw eckit::BadParameter("Cannot convert string to int");
+        throw BadParameter("Cannot convert string to int");
       }
 
       /// \brief Get the data at the index as an float.
       /// \return Float data.
       float getAsFloat(size_t idx) const
       {
-        throw eckit::BadParameter("Cannot convert string to float");
+        throw BadParameter("Cannot convert string to float");
       }
 
       /// \brief Get the data at the index as an string.
@@ -946,21 +947,21 @@ namespace bufr {
       /// \param val Scalar to multiply to the data.
       void multiplyBy(double val) final
       {
-        throw eckit::BadParameter("Trying to multiply a string by a number");
+        throw BadParameter("Trying to multiply a string by a number");
       }
 
       /// \brief Wrap the stored values into a range of values
       /// \param range The range to wrap the data into.
       void wrap(std::vector<float> range) final
       {
-        throw eckit::BadParameter("Can't wrap a string field.");
+        throw BadParameter("Can't wrap a string field.");
       }
 
       /// \brief Add a scalar to the stored values in this data object (string version).
       /// \param val Scalar to add to the data.
       void offsetBy(double val) final
       {
-        throw eckit::BadParameter("Trying to offset a string by a number");
+        throw BadParameter("Trying to offset a string by a number");
       }
 
       /// \brief Set the data associated with this data object (string DataObject).
@@ -1018,7 +1019,7 @@ namespace bufr {
           std::ostringstream str;
           str << "Can not write data of type " << typeid(std::string).name() << " with writer of type ";
           str << typeid(writer).name();
-          throw eckit::BadParameter(str.str());
+          throw BadParameter(str.str());
         }
       }
 
@@ -1301,7 +1302,7 @@ namespace bufr {
         {
           std::ostringstream str;
           str << "Supplied mask does not match the number of rows in the data object.";
-          throw eckit::BadParameter(str.str());
+          throw BadParameter(str.str());
         }
 
         const int newNumRows = std::accumulate(mask.begin(), mask.end(), 0);
@@ -1331,7 +1332,7 @@ namespace bufr {
         {
           std::ostringstream str;
           str << "Cannot append data of type " << typeid(data).name();
-          throw eckit::BadParameter(str.str());
+          throw BadParameter(str.str());
         }
 
         dims_[0] += other->dims_[0];
@@ -1341,7 +1342,7 @@ namespace bufr {
           {
             std::ostringstream str;
             str << "Cannot append data with different dimensions.";
-            throw eckit::BadParameter(str.str());
+            throw BadParameter(str.str());
           }
         }
         data_.insert(data_.end(), other->data_.begin(), other->data_.end());
@@ -1370,7 +1371,7 @@ namespace bufr {
             std::stringstream errStr;
             errStr << "Dimension " << name << " has an invalid source field. ";
             errStr << "The values do not repeat in each sequence.";
-            throw eckit::BadParameter(errStr.str());
+            throw BadParameter(errStr.str());
           }
         }
 

--- a/core/include/bufr/QueryParser.h
+++ b/core/include/bufr/QueryParser.h
@@ -8,6 +8,7 @@
 #include <unordered_set>
 
 #include "Tokenizer.h"
+#include "bufr/Exceptions.h"
 
 namespace bufr {
 
@@ -49,7 +50,7 @@ namespace bufr {
             }
             else
             {
-                throw eckit::BadParameter("QueryParser::parseQueryToken: Invalid subset in query "
+                throw BadParameter("QueryParser::parseQueryToken: Invalid subset in query "
                                           "string: " + component->name);
             }
 
@@ -71,7 +72,7 @@ namespace bufr {
         {
             if (tokens.size() < 1 && tokens.size() > 2)
             {
-                throw eckit::BadParameter("QueryParser::parseQueryToken: Invalid path component "
+                throw BadParameter("QueryParser::parseQueryToken: Invalid path component "
                                           "query string: " + tokens[0]->str());
             }
 
@@ -83,7 +84,7 @@ namespace bufr {
             }
             else
             {
-                throw eckit::BadParameter("QueryParser::parseQueryToken: Invalid path component "
+                throw BadParameter("QueryParser::parseQueryToken: Invalid path component "
                                           "query string: " + tokens[0]->str());
             }
 
@@ -134,7 +135,7 @@ namespace bufr {
             }
             else
             {
-                throw eckit::BadParameter(
+                throw BadParameter(
                     "QueryParser::parseQueryToken: Invalid query string: " + queryStr_);
             }
 
@@ -165,7 +166,7 @@ namespace bufr {
                 }
                 else
                 {
-                    throw eckit::BadParameter(
+                    throw BadParameter(
                         "QueryParser::parseQueryToken: Invalid query string: " + queryStr_);
                 }
             }

--- a/core/include/bufr/Tokenizer.h
+++ b/core/include/bufr/Tokenizer.h
@@ -12,7 +12,7 @@
 #include <sstream>
 #include <set>
 
-#include "eckit/exception/Exceptions.h"
+#include "bufr/Exceptions.h"
 
 
 namespace bufr {
@@ -34,7 +34,7 @@ namespace bufr {
 
     /// \brief Get the subtokens for this token.
     virtual std::vector<std::shared_ptr<QueryToken>> queryTokens() const {
-      throw eckit::BadParameter("Token::queryTokens: called on wrong token type" + debugStr());
+      throw BadParameter("Token::queryTokens: called on wrong token type" + debugStr());
     }
 
   protected:
@@ -155,7 +155,7 @@ namespace bufr {
           }
         }
       } else {
-        throw eckit::BadParameter("FilterToken::indices: invalid filter: " + str_);
+        throw BadParameter("FilterToken::indices: invalid filter: " + str_);
       }
 
       indices_ = std::vector<size_t>(indices.begin(), indices.end());
@@ -218,7 +218,7 @@ namespace bufr {
         else if (auto index = IndexToken::parse(start, end))
           subTokens_.push_back(index);
         else
-          throw eckit::BadValue("Failed to parse query " + std::string(start, end));
+          throw BadValue("Failed to parse query " + std::string(start, end));
       }
     }
 
@@ -287,7 +287,7 @@ namespace bufr {
           queries_.push_back(QueryToken::parse(matchStart, matchEnd));
         }
       } else {
-        throw eckit::BadParameter("Invalid multi query " + str_ + ".");
+        throw BadParameter("Invalid multi query " + str_ + ".");
       }
     }
 
@@ -301,7 +301,7 @@ namespace bufr {
         if (auto sep = std::dynamic_pointer_cast<QueryToken>(token)) {
           queryTokens.push_back(token);
         } else {
-          throw eckit::BadParameter("ParseError: Expected list of queries" + str_ + ".");
+          throw BadParameter("ParseError: Expected list of queries" + str_ + ".");
         }
       }
 

--- a/core/include/bufr/encoders/netcdf/NetcdfHelper.h
+++ b/core/include/bufr/encoders/netcdf/NetcdfHelper.h
@@ -11,7 +11,7 @@
 #include <netcdf>
 #include <ostream>
 
-#include "eckit/exception/Exceptions.h"
+#include "bufr/Exceptions.h"
 
 namespace nc = netCDF;
 

--- a/core/src/bufr/BufrReader/BufrParser.cpp
+++ b/core/src/bufr/BufrReader/BufrParser.cpp
@@ -14,7 +14,7 @@
 #include "bufr/ResultSet.h"
 #include "bufr/Export.h"
 #include "bufr/Split.h"
-#include "eckit/exception/Exceptions.h"
+#include "bufr/Exceptions.h"
 #include "../Log.h"
 
 namespace bufr {

--- a/core/src/bufr/BufrReader/Exports/Export.cpp
+++ b/core/src/bufr/BufrReader/Exports/Export.cpp
@@ -5,7 +5,7 @@
 #include <ostream>
 #include <iostream>
 
-#include "eckit/exception/Exceptions.h"
+#include "bufr/Exceptions.h"
 
 #include "Filters/BoundingFilter.h"
 #include "Splits/CategorySplit.h"
@@ -87,7 +87,7 @@ namespace bufr {
         }
         else
         {
-            throw eckit::BadParameter("Missing export::variables section in configuration.");
+            throw BadParameter("Missing export::variables section in configuration.");
         }
 
         //  Make sure the groupByVariable field is valid.
@@ -105,7 +105,7 @@ namespace bufr {
 
             if (!groupByFound)
             {
-                throw eckit::BadParameter(
+                throw BadParameter(
                     "Group by variable not found in export::variables section.");
             }
         }
@@ -138,7 +138,7 @@ namespace bufr {
         {
             std::stringstream errStr;
             errStr << "bufr::exports::variables must contain a dictionary of variables!";
-            throw eckit::BadParameter(errStr.str());
+            throw BadParameter(errStr.str());
         }
 
         for (const auto& key : conf.keys())
@@ -177,7 +177,7 @@ namespace bufr {
         {
             std::stringstream errStr;
             errStr << "bufr::exports::splits must contain a dictionary of splits!";
-            throw eckit::BadParameter(errStr.str());
+            throw BadParameter(errStr.str());
         }
 
         for (const auto& key : conf.keys())
@@ -204,7 +204,7 @@ namespace bufr {
         {
             std::stringstream errStr;
             errStr << "bufr::exports::filters must contain a list of filters!";
-            throw eckit::BadParameter(errStr.str());
+            throw BadParameter(errStr.str());
         }
 
         for (const auto& subConf : subConfs)

--- a/core/src/bufr/BufrReader/Exports/Filters/BoundingFilter.cpp
+++ b/core/src/bufr/BufrReader/Exports/Filters/BoundingFilter.cpp
@@ -5,7 +5,7 @@
 #include <ostream>
 
 #include "Eigen/Dense"
-#include "eckit/exception/Exceptions.h"
+#include "bufr/Exceptions.h"
 
 namespace
 {
@@ -39,14 +39,14 @@ namespace bufr {
         {
             std::stringstream errStr;
             errStr << "BoundingFilter must contain either upperBound, lowerBound or both.";
-            throw eckit::BadParameter(errStr.str());
+            throw BadParameter(errStr.str());
         }
 
         if (upperBound_ && lowerBound_ && (*upperBound_ < *lowerBound_))
         {
             std::stringstream errStr;
             errStr << "BoundingFilter upperBound must be greater or equal to lowerBound";
-            throw eckit::BadParameter(errStr.str());
+            throw BadParameter(errStr.str());
         }
     }
 
@@ -57,7 +57,7 @@ namespace bufr {
         {
             std::ostringstream errStr;
             errStr << "Unknown variable " << variable_ << " found in bounding filter.";
-            throw eckit::BadParameter(errStr.str());
+            throw BadParameter(errStr.str());
         }
 
         if (const auto& var = std::dynamic_pointer_cast<DataObject<float>>(dataMap.at(variable_)))
@@ -106,7 +106,7 @@ namespace bufr {
         {
             std::stringstream errStr;
             errStr << "BoundingFilter variable must be a array of numbers (found list of strings).";
-            throw eckit::BadParameter(errStr.str());
+            throw BadParameter(errStr.str());
         }
     }
 }  // namespace bufr

--- a/core/src/bufr/BufrReader/Exports/Splits/CategorySplit.cpp
+++ b/core/src/bufr/BufrReader/Exports/Splits/CategorySplit.cpp
@@ -4,7 +4,7 @@
 
 #include <ostream>
 
-#include "eckit/exception/Exceptions.h"
+#include "bufr/Exceptions.h"
 
 namespace
 {
@@ -101,7 +101,7 @@ namespace bufr {
                     std::stringstream errStr;
                     errStr << "Can not turn " << variable_ << " into a category as it contains ";
                     errStr << "non-integer values.";
-                    throw eckit::BadParameter(errStr.str());
+                    throw BadParameter(errStr.str());
                 }
             }
         }
@@ -110,7 +110,7 @@ namespace bufr {
         {
             std::stringstream errStr;
             errStr << "No categories could be identified for " << variable_ << ".";
-            throw eckit::BadParameter(errStr.str());
+            throw BadParameter(errStr.str());
         }
     }
 }  // namespace bufr

--- a/core/src/bufr/BufrReader/Exports/Variables/AircraftAltitudeVariable.cpp
+++ b/core/src/bufr/BufrReader/Exports/Variables/AircraftAltitudeVariable.cpp
@@ -10,7 +10,7 @@
 
 #include "bufr/DataObject.h"
 #include "../../../DataObjectBuilder.h"
-#include "eckit/exception/Exceptions.h"
+#include "bufr/Exceptions.h"
 
 namespace
 {
@@ -73,7 +73,7 @@ namespace bufr {
             {
                 std::ostringstream errStr;
                 errStr << "Inconsistent dimensions found in source data.";
-                throw eckit::BadParameter(errStr.str());
+                throw BadParameter(errStr.str());
             }
         }
 
@@ -162,7 +162,7 @@ namespace bufr {
 
         if (isKeyMissing)
         {
-            throw eckit::BadParameter(errStr.str());
+            throw BadParameter(errStr.str());
         }
     }
 

--- a/core/src/bufr/BufrReader/Exports/Variables/DatetimeVariable.cpp
+++ b/core/src/bufr/BufrReader/Exports/Variables/DatetimeVariable.cpp
@@ -12,7 +12,7 @@
 
 #include "../../../Log.h"
 #include "../../../DataObjectBuilder.h"
-#include "eckit/exception/Exceptions.h"
+#include "bufr/Exceptions.h"
 
 
 #include "bufr/DataObject.h"
@@ -80,7 +80,7 @@ namespace bufr {
         || (!secondQuery_.empty() && !yearVar->hasSamePath(map.at(getExportKey(ConfKeys::Second))))) {
       std::ostringstream errStr;
       errStr << "Datetime variables are not all from the same path.";
-      throw eckit::BadParameter(errStr.str());
+      throw BadParameter(errStr.str());
     }
 
     for (unsigned int idx = 0; idx < map.at(getExportKey(ConfKeys::Year))->size(); idx++) {
@@ -162,7 +162,7 @@ namespace bufr {
     errStr << " could not be found during export of datetime object.";
 
     if (isKeyMissing) {
-      throw eckit::BadParameter(errStr.str());
+      throw BadParameter(errStr.str());
     }
   }
 

--- a/core/src/bufr/BufrReader/Exports/Variables/QueryVariable.cpp
+++ b/core/src/bufr/BufrReader/Exports/Variables/QueryVariable.cpp
@@ -5,7 +5,7 @@
 #include <ostream>
 
 #include "Transforms/TransformBuilder.h"
-#include "eckit/exception/Exceptions.h"
+#include "bufr/Exceptions.h"
 
 namespace
 {
@@ -33,7 +33,7 @@ namespace bufr {
             std::stringstream errStr;
             errStr << "Export named " << getExportName();
             errStr << " could not be found during export.";
-            throw eckit::BadParameter(errStr.str());
+            throw BadParameter(errStr.str());
         }
 
         auto dataObject = map.at(getExportName());

--- a/core/src/bufr/BufrReader/Exports/Variables/RemappedBrightnessTemperatureVariable.cpp
+++ b/core/src/bufr/BufrReader/Exports/Variables/RemappedBrightnessTemperatureVariable.cpp
@@ -14,7 +14,7 @@
 #include "DatetimeVariable.h"
 #include "Transforms/atms/atms_spatial_average_interface.h"
 #include "Transforms/spatial_averaging/spatial_average_interface.h"
-#include "eckit/exception/Exceptions.h"
+#include "bufr/Exceptions.h"
 
 
 namespace
@@ -119,19 +119,19 @@ namespace bufr {
             auto& rainflagObj = map.at(getExportKey(ConfKeys::RainFlag));
             if (!conf_.has(ConfKeys::SatelliteId))
             {
-              throw eckit::BadParameter("SatelliteId is missing for SSMIS.");
+              throw BadParameter("SatelliteId is missing for SSMIS.");
             }
             if (!conf_.has(ConfKeys::Longitude))
             {
-              throw eckit::BadParameter("Longitude is missing for SSMIS.");
+              throw BadParameter("Longitude is missing for SSMIS.");
             }            
             if (!conf_.has(ConfKeys::Latitude))
             {
-              throw eckit::BadParameter("Latitude is missing for SSMIS.");
+              throw BadParameter("Latitude is missing for SSMIS.");
             }            
             if (!conf_.has(ConfKeys::RainFlag))
             {
-              throw eckit::BadParameter("RainFlag is missing for SSMIS.");
+              throw BadParameter("RainFlag is missing for SSMIS.");
             }            
 
 	    // Get satid
@@ -160,7 +160,7 @@ namespace bufr {
        	else
        	{
 
-            throw eckit::BadParameter("Invalid sensor type: " + sensorOption +
+            throw BadParameter("Invalid sensor type: " + sensorOption +
                                       ". Must be either ATMS or SSMIS.");
         }
 
@@ -202,7 +202,7 @@ namespace bufr {
 
         if (isKeyMissing)
         {
-            throw eckit::BadParameter(errStr.str());
+            throw BadParameter(errStr.str());
         }
     }
 

--- a/core/src/bufr/BufrReader/Exports/Variables/SensorScanAngleVariable.cpp
+++ b/core/src/bufr/BufrReader/Exports/Variables/SensorScanAngleVariable.cpp
@@ -10,7 +10,7 @@
 
 #include "bufr/DataObject.h"
 #include "../../../DataObjectBuilder.h"
-#include "eckit/exception/Exceptions.h"
+#include "bufr/Exceptions.h"
 
 namespace
 {
@@ -68,7 +68,7 @@ namespace bufr {
 
         // Required parameters
         if (!conf_.has(ConfKeys::Sensor) || !conf_.has(ConfKeys::ScanStart) || !conf_.has(ConfKeys::ScanStep)) {
-            throw eckit::BadParameter("Missing required parameters: sensor, scanStart and scanStep are required. Check configuration.");
+            throw BadParameter("Missing required parameters: sensor, scanStart and scanStep are required. Check configuration.");
         }
 
         // Extract required parameters
@@ -141,7 +141,7 @@ namespace bufr {
 
         if (isKeyMissing)
         {
-            throw eckit::BadParameter(errStr.str());
+            throw BadParameter(errStr.str());
         }
     }
 

--- a/core/src/bufr/BufrReader/Exports/Variables/SensorScanPositionVariable.cpp
+++ b/core/src/bufr/BufrReader/Exports/Variables/SensorScanPositionVariable.cpp
@@ -11,7 +11,7 @@
 #include <unordered_map>
 #include <vector>
 
-#include "eckit/exception/Exceptions.h"
+#include "bufr/Exceptions.h"
 #include "bufr/DataObject.h"
 #include "../../../DataObjectBuilder.h"
 #include "../../../Log.h"
@@ -50,7 +50,7 @@ namespace bufr {
         }
         else
         {
-            throw eckit::BadParameter("Missing required parameters: sensor"
+            throw BadParameter("Missing required parameters: sensor"
                                       "Check your configuration.");
         }
 
@@ -115,7 +115,7 @@ namespace bufr {
 
         if (isKeyMissing)
         {
-            throw eckit::BadParameter(errStr.str());
+            throw BadParameter(errStr.str());
         }
     }
 

--- a/core/src/bufr/BufrReader/Exports/Variables/SpectralRadianceVariable.cpp
+++ b/core/src/bufr/BufrReader/Exports/Variables/SpectralRadianceVariable.cpp
@@ -13,7 +13,7 @@
 
 #include "bufr/DataObject.h"
 #include "../../../DataObjectBuilder.h"
-#include "eckit/exception/Exceptions.h"
+#include "bufr/Exceptions.h"
 
 namespace
 {
@@ -140,7 +140,7 @@ namespace bufr {
 
         if (isKeyMissing)
         {
-            throw eckit::BadParameter(errStr.str());
+            throw BadParameter(errStr.str());
         }
     }
 

--- a/core/src/bufr/BufrReader/Exports/Variables/TimeoffsetVariable.cpp
+++ b/core/src/bufr/BufrReader/Exports/Variables/TimeoffsetVariable.cpp
@@ -10,7 +10,7 @@
 #include <unordered_map>
 #include <vector>
 
-#include "eckit/exception/Exceptions.h"
+#include "bufr/Exceptions.h"
 
 #include "bufr/DataObject.h"
 #include "Transforms/TransformBuilder.h"
@@ -60,7 +60,7 @@ namespace bufr {
         {
             std::ostringstream errStr;
             errStr << "Reference time MUST be formatted like 2021-11-29T22:43:51Z";
-            throw eckit::BadParameter(errStr.str());
+            throw BadParameter(errStr.str());
         }
 
         auto timeOffsets = map.at(getExportKey(ConfKeys::Timeoffset));
@@ -118,7 +118,7 @@ namespace bufr {
 
         if (isKeyMissing)
         {
-            throw eckit::BadParameter(errStr.str());
+            throw BadParameter(errStr.str());
         }
     }
 

--- a/core/src/bufr/BufrReader/Exports/Variables/Transforms/TransformBuilder.cpp
+++ b/core/src/bufr/BufrReader/Exports/Variables/Transforms/TransformBuilder.cpp
@@ -2,7 +2,7 @@
 
 #include "TransformBuilder.h"
 
-#include "eckit/exception/Exceptions.h"
+#include "bufr/Exceptions.h"
 
 #include "ScalingTransform.h"
 #include "OffsetTransform.h"
@@ -32,7 +32,7 @@ namespace bufr {
         }
         else
         {
-            throw eckit::BadParameter("Tried to create unknown export transform type. "
+            throw BadParameter("Tried to create unknown export transform type. "
                                       "Check your configuration.");
         }
 

--- a/core/src/bufr/BufrReader/Exports/Variables/WigosidVariable.cpp
+++ b/core/src/bufr/BufrReader/Exports/Variables/WigosidVariable.cpp
@@ -12,7 +12,7 @@
 #include <string>
 #include <sstream>
 
-#include "eckit/exception/Exceptions.h"
+#include "bufr/Exceptions.h"
 
 #include "bufr/DataObject.h"
 #include "../../../DataObjectBuilder.h"
@@ -61,7 +61,7 @@ namespace bufr {
         {
             std::ostringstream errStr;
             errStr << "Wigosid variables are not all from the same path.";
-            throw eckit::BadParameter(errStr.str());
+            throw BadParameter(errStr.str());
         }
 
         for (unsigned int idx = 0; idx < map.at(getExportKey(ConfKeys::Wgosids))->size(); idx++)
@@ -121,7 +121,7 @@ namespace bufr {
 
         if (isKeyMissing)
         {
-            throw eckit::BadParameter(errStr.str());
+            throw BadParameter(errStr.str());
         }
     }
 

--- a/core/src/bufr/BufrReader/Query/DataProvider/DataProvider.cpp
+++ b/core/src/bufr/BufrReader/Query/DataProvider/DataProvider.cpp
@@ -8,7 +8,7 @@
 #include <iostream>
 #include <unordered_map>
 
-#include "eckit/exception/Exceptions.h"
+#include "bufr/Exceptions.h"
 
 
 namespace bufr {
@@ -22,7 +22,7 @@ namespace bufr {
         {
             std::ostringstream errStr;
             errStr << "Tried to call DataProvider::run, but the file is not open!";
-            throw eckit::BadParameter(errStr.str());
+            throw BadParameter(errStr.str());
         }
 
         static int SubsetLen = 9;
@@ -74,7 +74,7 @@ namespace bufr {
             std::ostringstream errStr;
             errStr << "No BUFR messages were found! ";
             errStr << "Please make sure that " << filePath_ << " exists and is a valid BUFR file.";
-            throw eckit::BadValue(errStr.str());
+            throw BadValue(errStr.str());
         }
 
         if (!foundBufrSubset)
@@ -84,7 +84,7 @@ namespace bufr {
             errStr << "Please make sure you are querying for valid subsets that exist in ";
             errStr << filePath_ << ". ";
             errStr << "Otherwise there might be a problem with the BUFR file (no subsets).";
-            throw eckit::BadValue(errStr.str());
+            throw BadValue(errStr.str());
         }
     }
 
@@ -94,7 +94,7 @@ namespace bufr {
       {
         std::ostringstream errStr;
         errStr << "Tried to call DataProvider::numMessages, but the file is not open!";
-        throw eckit::BadParameter(errStr.str());
+        throw BadParameter(errStr.str());
       }
 
       static int SubsetLen = 9;

--- a/core/src/bufr/BufrReader/Query/DataProvider/WmoDataProvider.cpp
+++ b/core/src/bufr/BufrReader/Query/DataProvider/WmoDataProvider.cpp
@@ -9,7 +9,7 @@
 #include <iostream>
 #include <sstream>
 
-#include "eckit/exception/Exceptions.h"
+#include "bufr/Exceptions.h"
 #include "bufr_interface.h"
 
 namespace bufr {
@@ -123,7 +123,7 @@ namespace bufr {
         {
             std::ostringstream errStr;
             errStr << "Tried to call DataProvider::initAllTableData, but the file is already open!";
-            throw eckit::BadParameter(errStr.str());
+            throw BadParameter(errStr.str());
         }
 
         // Run through each message subset in order to cache the table information.

--- a/core/src/bufr/BufrReader/Query/QueryParser.cpp
+++ b/core/src/bufr/BufrReader/Query/QueryParser.cpp
@@ -5,7 +5,7 @@
 #include <iostream>
 #include <algorithm>
 
-#include "eckit/exception/Exceptions.h"
+#include "bufr/Exceptions.h"
 
 namespace bufr {
     std::vector<Query> QueryParser::parse(const std::string& queryStr)
@@ -14,7 +14,7 @@ namespace bufr {
 
         if (tokens.empty())
         {
-            throw eckit::BadParameter("QueryParser::parse: Invalid query string: " + queryStr);
+            throw BadParameter("QueryParser::parse: Invalid query string: " + queryStr);
         }
 
         const auto& token = tokens[0];
@@ -22,7 +22,7 @@ namespace bufr {
         if (!std::dynamic_pointer_cast<QueryToken>(token) &&
             !std::dynamic_pointer_cast<MultiQueryToken>(token))
         {
-            throw eckit::BadParameter("QueryParser::parse: Invalid query string: " + queryStr);
+            throw BadParameter("QueryParser::parse: Invalid query string: " + queryStr);
         }
 
         std::vector<Query> queries;

--- a/core/src/bufr/BufrReader/Query/ResultSetImpl.cpp
+++ b/core/src/bufr/BufrReader/Query/ResultSetImpl.cpp
@@ -6,7 +6,7 @@
 #include <iostream>
 #include <string>
 
-#include "eckit/exception/Exceptions.h"
+#include "bufr/Exceptions.h"
 
 #include "VectorMath.h"
 #include "bufr/DataObject.h"
@@ -21,7 +21,7 @@ namespace bufr {
     // Make sure we have accumulated frames otherwise something is wrong.
     if (frames_.size() == 0)
     {
-      throw eckit::BadValue("ResultSet has no data.");
+      throw BadValue("ResultSet has no data.");
     }
 
     // Get the metadata for the target
@@ -294,7 +294,7 @@ namespace bufr {
         errStr << "The GroupBy and Target Fields do not share a common path.\n";
         errStr << "GroupByField path: " << groupByPath.str() << std::endl;
         errStr << "TargetField path: " << targetPath.str() << std::endl;
-        throw eckit::BadParameter(errStr.str());
+        throw BadParameter(errStr.str());
       }
     }
   }
@@ -428,7 +428,7 @@ namespace bufr {
         std::ostringstream errMsg;
         errMsg << "Conversions between numbers and strings are not currently supported. ";
         errMsg << "See the export definition for \"" << fieldName << "\".";
-        throw eckit::BadParameter(errMsg.str());
+        throw BadParameter(errMsg.str());
       }
     }
 
@@ -491,7 +491,7 @@ namespace bufr {
     } else {
       std::ostringstream errMsg;
       errMsg << "Unknown or unsupported type " << overrideType << ".";
-      throw eckit::BadParameter(errMsg.str());
+      throw BadParameter(errMsg.str());
     }
 
     return object;

--- a/core/src/bufr/DataContainer.cpp
+++ b/core/src/bufr/DataContainer.cpp
@@ -5,7 +5,7 @@
 #include <string>
 #include <ostream>
 
-#include "eckit/exception/Exceptions.h"
+#include "bufr/Exceptions.h"
 
 #include "Log.h"
 
@@ -23,7 +23,7 @@ namespace bufr {
       std::ostringstream errorStr;
       errorStr << "ERROR: Field called " << fieldName << " already exists ";
       errorStr << "for subcategory " << makeSubCategoryStr(categoryId) << std::endl;
-      throw eckit::BadParameter(errorStr.str());
+      throw BadParameter(errorStr.str());
     }
 
     dataSets_.at(categoryId).insert({dropPath(fieldName), data});
@@ -38,7 +38,7 @@ namespace bufr {
         errStr << " or category " << makeSubCategoryStr(categoryId);
         errStr << " does not exist. Cannot set non-existent field.";
 
-        throw eckit::BadParameter(errStr.str());
+        throw BadParameter(errStr.str());
     }
 
     dataSets_.at(categoryId).at(dropPath(fieldName)) = data;
@@ -52,7 +52,7 @@ namespace bufr {
       errStr << " or category " << makeSubCategoryStr(categoryId);
       errStr << " does not exist.";
 
-      throw eckit::BadParameter(errStr.str());
+      throw BadParameter(errStr.str());
     }
 
     return dataSets_.at(categoryId).at(dropPath(fieldName));
@@ -79,7 +79,7 @@ namespace bufr {
       errStr << " or category " << makeSubCategoryStr(categoryId);
       errStr << " does not exist.";
 
-      throw eckit::BadParameter(errStr.str());
+      throw BadParameter(errStr.str());
     }
 
     auto& dataObject             = dataSets_.at(categoryId).at(dropPath(fieldName));
@@ -144,7 +144,7 @@ namespace bufr {
       errStr << "ERROR: Category called " << makeSubCategoryStr(categoryId);
       errStr << " does not exist.";
 
-      throw eckit::BadParameter(errStr.str());
+      throw BadParameter(errStr.str());
     }
 
     return subCategory;
@@ -156,7 +156,7 @@ namespace bufr {
       errStr << "ERROR: Category called " << makeSubCategoryStr(categoryId);
       errStr << " does not exist.";
 
-      throw eckit::BadParameter(errStr.str());
+      throw BadParameter(errStr.str());
     }
 
     return dataSets_.at(categoryId).begin()->second->getDims().at(0);
@@ -263,7 +263,7 @@ namespace bufr {
             errStr << "Error: encountered mismatch when combining DataContainers.";
             errStr << " Field \"" << field << "\" category \"" << makeSubCategoryStr(subCat)
                    << "\" does not exist in this DataContainer.";
-            throw eckit::BadParameter(errStr.str());
+            throw BadParameter(errStr.str());
           }
 
           get(field, subCat)->append(other.get(field, subCat));
@@ -326,7 +326,7 @@ namespace bufr {
       std::ostringstream errStr;
       errStr << "ERROR: The category " << makeSubCategoryStr(categoryId);
       errStr << " does not exist. Cannot apply the mask.";
-      throw eckit::BadParameter(errStr.str());
+      throw BadParameter(errStr.str());
     }
 
     for (const auto &field: getFieldNames())

--- a/core/src/bufr/DataObjectBuilder.h
+++ b/core/src/bufr/DataObjectBuilder.h
@@ -9,6 +9,7 @@
 #include "bufr/DataProvider.h"
 #include "bufr/DataObject.h"
 #include "bufr/SubsetTable.h"
+#include "bufr/Exceptions.h"
 
 
 namespace bufr {
@@ -38,7 +39,7 @@ namespace bufr {
           std::ostringstream errMsg;
           errMsg << "Conversions between numbers and strings are not currently supported. ";
           errMsg << "See the export definition for \"" << fieldName << "\".";
-          throw eckit::BadParameter(errMsg.str());
+          throw BadParameter(errMsg.str());
         }
       }
 
@@ -124,7 +125,7 @@ namespace bufr {
       } else {
         std::ostringstream errMsg;
         errMsg << "Unknown or unsupported type " << overrideType << ".";
-        throw eckit::BadParameter(errMsg.str());
+        throw BadParameter(errMsg.str());
       }
 
       return object;

--- a/core/src/bufr/ObjectFactory.h
+++ b/core/src/bufr/ObjectFactory.h
@@ -7,7 +7,7 @@
 #include <string>
 #include <ostream>
 
-#include "eckit/exception/Exceptions.h"
+#include "bufr/Exceptions.h"
 
 
 namespace bufr {
@@ -64,7 +64,7 @@ namespace bufr {
             {
                 std::ostringstream errStr;
                 errStr << "Trying to use unregistered object named " << objectName << ".";
-                throw eckit::BadParameter(errStr.str());
+                throw BadParameter(errStr.str());
             }
 
             return makers_[objectName]->make(args...);
@@ -83,7 +83,7 @@ namespace bufr {
                 errStr << objectName;
                 errStr << ". Name must be unique.";
 
-                throw eckit::BadParameter(errStr.str());
+                throw BadParameter(errStr.str());
             }
 
             makers_.insert({objectName, std::make_shared<ObjectMaker<T>>()});

--- a/core/src/encoders/Description.cpp
+++ b/core/src/encoders/Description.cpp
@@ -2,7 +2,7 @@
 
 #include "bufr/encoders/Description.h"
 
-#include "eckit/exception/Exceptions.h"
+#include "bufr/Exceptions.h"
 #include "eckit/config/YAMLConfiguration.h"
 #include "eckit/filesystem/PathName.h"
 
@@ -79,7 +79,7 @@ namespace encoders {
             {
                 std::stringstream errStr;
                 errStr << "netcdf dimensions must contain a list of dimensions!";
-                throw eckit::BadParameter(errStr.str());
+                throw BadParameter(errStr.str());
             }
 
             for (const auto &dimConf: dimConfs)
@@ -99,7 +99,7 @@ namespace encoders {
                         QueryParser::parse(dimConf.getString(ConfKeys::Dimension::Path));
                 } else
                 {
-                    throw eckit::BadParameter(
+                    throw BadParameter(
                         R"(dimensions section must have either "path" or "paths".)");
                 }
 
@@ -122,7 +122,7 @@ namespace encoders {
         {
             std::stringstream errStr;
             errStr << "netcdf variables must contain a list of variables!";
-            throw eckit::BadParameter(errStr.str());
+            throw BadParameter(errStr.str());
         }
 
         for (const auto &varConf: varConfs)
@@ -175,7 +175,7 @@ namespace encoders {
                 int compressionLevel = varConf.getInt(ConfKeys::Variable::CompressionLevel);
                 if (compressionLevel < 0 || compressionLevel > 9)
                 {
-                    throw eckit::BadParameter("GZip compression level must be a number 0-9");
+                    throw BadParameter("GZip compression level must be a number 0-9");
                 }
 
                 variable.compressionLevel = varConf.getInt(ConfKeys::Variable::CompressionLevel);
@@ -226,7 +226,7 @@ namespace encoders {
                     addGlobal(global);
                 } else
                 {
-                    throw eckit::BadParameter("Unsupported global attribute type");
+                    throw BadParameter("Unsupported global attribute type");
                 }
             }
         }
@@ -238,7 +238,7 @@ namespace encoders {
         {
             std::stringstream errStr;
             errStr << "Dimension " << dim.name << " can not have both source and labels.";
-            throw eckit::BadParameter(errStr.str());
+            throw BadParameter(errStr.str());
         }
 
         dimensions_.push_back(dim);
@@ -260,7 +260,7 @@ namespace encoders {
         {
             std::stringstream errStr;
             errStr << "Variable " << name << " not found.";
-            throw eckit::BadParameter(errStr.str());
+            throw BadParameter(errStr.str());
         }
 
         variables_.erase(it);
@@ -298,7 +298,7 @@ namespace encoders {
         {
             std::stringstream errStr;
             errStr << "Dimension " << name << " not found.";
-            throw eckit::BadParameter(errStr.str());
+            throw BadParameter(errStr.str());
         }
 
         dimensions_.erase(it);
@@ -315,7 +315,7 @@ namespace encoders {
         {
             std::stringstream errStr;
             errStr << "Global " << name << " not found.";
-            throw eckit::BadParameter(errStr.str());
+            throw BadParameter(errStr.str());
         }
 
         globals_.erase(it);
@@ -349,7 +349,7 @@ namespace encoders {
         {
             if (range.size() != 2)
             {
-                throw eckit::BadParameter("Range is the wrong size.");
+                throw BadParameter("Range is the wrong size.");
             }
 
             auto newRange = std::make_shared<Range>();

--- a/core/src/encoders/EncoderBase.cpp
+++ b/core/src/encoders/EncoderBase.cpp
@@ -37,7 +37,7 @@ namespace encoders {
         {
           std::ostringstream errStr;
           errStr << "Could not find dimension for path " << path.str();
-          throw eckit::BadParameter(errStr.str());
+          throw BadParameter(errStr.str());
         }
       }
 
@@ -46,7 +46,7 @@ namespace encoders {
       {
         if (varDimNameMap[var.name].size() != 1)
         {
-          throw eckit::BadParameter(var.name + " variable must be one dimensional.");
+          throw BadParameter(var.name + " variable must be one dimensional.");
         }
       }
     }
@@ -78,7 +78,7 @@ namespace encoders {
           {
             std::ostringstream errStr;
             errStr << "Could not find dimension for path " << dimPath.str();
-            throw eckit::BadParameter(errStr.str());
+            throw BadParameter(errStr.str());
           }
         }
       }
@@ -89,7 +89,7 @@ namespace encoders {
           std::ostringstream errStr;
           errStr << "Number of chunk sizes does not match the number of dimensions for variable ";
           errStr << var.name;
-          throw eckit::BadParameter(errStr.str());
+          throw BadParameter(errStr.str());
         }
 
         size_t dimIdx = 0;
@@ -223,7 +223,7 @@ namespace encoders {
           std::stringstream errStr;
           errStr << "Source field " << descDim.source << " in ";
           errStr << descDim.name << " is not in the correct path.";
-          throw eckit::BadParameter(errStr.str());
+          throw BadParameter(errStr.str());
         }
 
         labels.resize(dataObject->getDims().back());
@@ -236,7 +236,7 @@ namespace encoders {
         }
         else
         {
-          throw eckit::BadParameter("Dimension data type not supported.");
+          throw BadParameter("Dimension data type not supported.");
         }
       }
       // Create the labels for specified by the "labels" field
@@ -250,7 +250,7 @@ namespace encoders {
           std::ostringstream errStr;
           errStr << "The number of labels (" << pathSize << ") ";
           errStr << "does not match the length of dimension \"" << descDim.name << "\".";
-          throw eckit::BadParameter(errStr.str());
+          throw BadParameter(errStr.str());
         }
       }
       // Set labels to the default (all 0's)
@@ -356,7 +356,7 @@ namespace encoders {
     }
     else
     {
-      throw eckit::BadParameter("Pattern " + str + " in dimension label is invalid.");
+      throw BadParameter("Pattern " + str + " in dimension label is invalid.");
     }
 
     return indices;
@@ -392,7 +392,7 @@ namespace encoders {
     }
     errStr << "in the container.";
 
-    throw eckit::BadParameter(errStr.str());
+    throw BadParameter(errStr.str());
   }
 
   bool EncoderBase::isDimPath(const std::shared_ptr<DataContainer>& container,

--- a/core/src/encoders/netcdf/Encoder.cpp
+++ b/core/src/encoders/netcdf/Encoder.cpp
@@ -11,7 +11,7 @@
 
 #include <netcdf>
 
-#include "eckit/exception/Exceptions.h"
+#include "bufr/Exceptions.h"
 
 #include "../../bufr/Log.h"
 #include "bufr/DataObject.h"
@@ -192,7 +192,7 @@ namespace netcdf {
         }
         else
         {
-            throw eckit::BadParameter("Unsupported type for NetCDF.");
+            throw BadParameter("Unsupported type for NetCDF.");
         }
 
         return var;
@@ -383,7 +383,7 @@ namespace netcdf {
                 std::ostringstream errStr;
                 errStr << "Prototype path string does not contain a substitution for " << key <<".";
                 errStr << " example: " << makePathPrototype(subMap);
-                throw eckit::BadParameter(errStr.str());
+                throw BadParameter(errStr.str());
             }
         }
 
@@ -399,7 +399,7 @@ namespace netcdf {
             {
                 std::ostringstream errStr;
                 errStr << "Can not find " << subs.first << ". No category with that name.";
-                throw eckit::BadParameter(errStr.str());
+                throw BadParameter(errStr.str());
             }
         }
 
@@ -446,7 +446,7 @@ namespace netcdf {
                 }
                 else
                 {
-                    throw eckit::BadParameter("Unmatched { found in output filename.");
+                    throw BadParameter("Unmatched { found in output filename.");
                 }
             }
         }
@@ -505,7 +505,7 @@ namespace netcdf {
         }
         else
         {
-            throw eckit::BadParameter("Variable name must contain a group name");
+            throw BadParameter("Variable name must contain a group name");
         }
 
         return std::make_pair(groupName, varName);

--- a/python/DataObjectFunctions.cpp
+++ b/python/DataObjectFunctions.cpp
@@ -11,6 +11,7 @@
 #include <regex>  // NOLINT
 
 #include "DataObjectFunctions.h"
+#include "bufr/Exceptions.h"
 
 #include <pybind11/pybind11.h>
 #include <pybind11/numpy.h>
@@ -111,7 +112,7 @@ namespace bufr {
     }
     else
     {
-      throw eckit::BadParameter("ERROR: Unsupported data type.");
+      throw bufr::BadParameter("ERROR: Unsupported data type.");
     }
 
     return dataObj;

--- a/python/py_data_container.cpp
+++ b/python/py_data_container.cpp
@@ -17,6 +17,7 @@
 #include "bufr/DataContainer.h"
 #include "bufr/Tokenizer.h"
 #include "bufr/QueryParser.h"
+#include "bufr/Exceptions.h"
 
 #include "DataObjectFunctions.h"
 #include "py_mpi.h"
@@ -49,7 +50,7 @@ void setupDataContainer(py::module& m)
             std::ostringstream errorStr;
             errorStr << "ERROR: Invalid category " << self.makeSubCategoryStr(categoryId);
             errorStr << " for field " << fieldName << "." << std::endl;
-            throw eckit::BadParameter(errorStr.str());
+            throw bufr::BadParameter(errorStr.str());
           }
 
           if (self.hasKey(fieldName, categoryId))
@@ -57,7 +58,7 @@ void setupDataContainer(py::module& m)
             std::ostringstream errorStr;
             errorStr << "ERROR: Field called " << fieldName << " already exists ";
             errorStr << "for subcategory " << self.makeSubCategoryStr(categoryId) << std::endl;
-            throw eckit::BadParameter(errorStr.str());
+            throw bufr::BadParameter(errorStr.str());
           }
 
           auto paths = std::vector<Query>(dimPaths.size());
@@ -104,21 +105,21 @@ void setupDataContainer(py::module& m)
           // Guard statements
           if (!self.hasKey(fieldName, categoryId))
           {
-            throw eckit::BadParameter("ERROR: Field " + fieldName +  " does not exist.");
+            throw bufr::BadParameter("ERROR: Field " + fieldName +  " does not exist.");
           }
 
           const auto& data = self.get(fieldName, categoryId);
 
           if (pyData.ndim() != data->getDims().size())
           {
-            throw eckit::BadParameter("ERROR: Dimension mismatch.");
+            throw bufr::BadParameter("ERROR: Dimension mismatch.");
           }
 
           for (size_t idx = 0; idx < pyData.ndim(); idx++)
           {
             if (pyData.shape(idx) != data->getDims()[idx])
             {
-              throw eckit::BadParameter("ERROR: Dimension mismatch.");
+              throw bufr::BadParameter("ERROR: Dimension mismatch.");
             }
           }
 

--- a/python/py_encoder_description.cpp
+++ b/python/py_encoder_description.cpp
@@ -14,6 +14,7 @@
 #include <string>
 
 #include "bufr/encoders/Description.h"
+#include "bufr/Exceptions.h"
 
 
 namespace py = pybind11;
@@ -173,12 +174,12 @@ void setupEncoderDescription(py::module& m)
            }
            else
            {
-             throw eckit::BadValue("Unsupported data type encountered.");
+             throw bufr::BadValue("Unsupported data type encountered.");
            }
          }
          else
          {
-           throw eckit::BadValue("Unsupported data type encountered.");
+           throw bufr::BadValue("Unsupported data type encountered.");
          }
        },
        py::arg("name"),

--- a/tools/bufr2netcdf/bufr2netcdf.cpp
+++ b/tools/bufr2netcdf/bufr2netcdf.cpp
@@ -9,7 +9,7 @@
 #include "eckit/runtime/Main.h"
 #include "eckit/mpi/Comm.h"
 #include "eckit/config/YAMLConfiguration.h"
-#include "eckit/exception/Exceptions.h"
+#include "bufr/Exceptions.h"
 #include "eckit/filesystem/PathName.h"
 
 #include "bufr/BufrParser.h"
@@ -93,7 +93,7 @@ namespace mpi {
     }
     else
     {
-        eckit::BadParameter("No section named \"encoder\"");
+        BadParameter("No section named \"encoder\"");
     }
 
     logElapsedTime("Total Time", startTime);
@@ -113,7 +113,7 @@ namespace mpi {
 
     if (!yaml->has("encoder"))
     {
-      throw eckit::BadParameter("No section named \"encoder\"");
+      throw BadParameter("No section named \"encoder\"");
     }
 
     auto parser = BufrParser(obsFile, yaml->getSubConfiguration("bufr"), tablePath);

--- a/tools/show_queries/NcepQueryPrinter.cpp
+++ b/tools/show_queries/NcepQueryPrinter.cpp
@@ -6,7 +6,7 @@
 #include <iostream>
 #include <sstream>
 
-#include "eckit/exception/Exceptions.h"
+#include "bufr/Exceptions.h"
 #include "bufr/NcepDataProvider.h"
 
 #include "QueryPrinter.h"
@@ -25,7 +25,7 @@ namespace bufr {
         {
             std::ostringstream errStr;
             errStr << "Tried to call QueryPrinter::getTable, but the file is already open!";
-            throw eckit::BadParameter(errStr.str());
+            throw BadParameter(errStr.str());
         }
 
         bool finished = false;
@@ -61,7 +61,7 @@ namespace bufr {
         {
             std::ostringstream errStr;
             errStr << "Tried to call QueryPrinter::getSubsetVariants but the file is already open!";
-            throw eckit::BadParameter(errStr.str());
+            throw BadParameter(errStr.str());
         }
 
         dataProvider_->open();

--- a/tools/show_queries/WmoQueryPrinter.cpp
+++ b/tools/show_queries/WmoQueryPrinter.cpp
@@ -9,7 +9,7 @@
 #include <unordered_set>
 #include <sstream>
 
-#include "eckit/exception/Exceptions.h"
+#include "bufr/Exceptions.h"
 
 #include "bufr/WmoDataProvider.h"
 #include "bufr/SubsetTable.h"
@@ -23,7 +23,7 @@ namespace bufr {
     if (dataProvider_->isFileOpen()) {
       std::ostringstream errStr;
       errStr << "Tried to call QueryPrinter::getTable, but the file is already open!";
-      throw eckit::BadParameter(errStr.str());
+      throw BadParameter(errStr.str());
     }
 
     dataProvider_->open();
@@ -60,7 +60,7 @@ namespace bufr {
     if (dataProvider_->isFileOpen()) {
       std::ostringstream errStr;
       errStr << "Tried to call QueryPrinter::getSubsetVariants but the file is already open!";
-      throw eckit::BadParameter(errStr.str());
+      throw BadParameter(errStr.str());
     }
 
     dataProvider_->open();


### PR DESCRIPTION
## Summary
- replace all `eckit` exceptions with `bufr` versions
- include new `bufr/Exceptions.h` where needed
- remove leftover `eckit` exception includes
- drop redundant `bufr::` prefix inside `bufr` namespace

## Testing
- `ctest -j4 --output-on-failure` *(fails: No tests were found)*

------
https://chatgpt.com/codex/tasks/task_e_683e1cb95ce4832592d849ec4eff7c2f