### PR TITLE
Expose BUFR exceptions to Python interface

### DIFF
--- a/docs/python_api.rst
+++ b/docs/python_api.rst
@@ -281,6 +281,30 @@ appropriate missing value using :func:`get_missing_value`.
    mv = bufr.get_missing_value(np.int64)
 
 
+Exceptions
+----------
+
+Custom exceptions from the underlying C++ library are exposed so that they can
+be caught explicitly in Python code.  The base class is ``bufr.Exception`` and
+the following derived exceptions are available:
+
+``bufr.BadParameter``
+    Raised when an invalid argument is supplied.
+``bufr.BadValue``
+    Raised when a value is outside the expected range.
+``bufr.MissingData``
+    Raised when required data are missing.
+
+.. code-block:: python
+
+   import bufr
+
+   try:
+       ...
+   except bufr.BadParameter:
+       handle_error()
+
+
 
 Low Level API
 -------------

--- a/python/py_bufr.cpp
+++ b/python/py_bufr.cpp
@@ -6,6 +6,7 @@
 */
 
 #include <pybind11/pybind11.h>
+#include "bufr/Exceptions.h"
 
 namespace py = pybind11;
 
@@ -24,6 +25,12 @@ void setupHelpers(py::module& m);
 PYBIND11_MODULE(bufr_python, m)
 {
   m.doc() = "Python bindings for the bufr library";
+
+  // Register custom exception classes so python can catch them
+  auto exc = py::register_exception<bufr::Exception>(m, "Exception");
+  py::register_exception<bufr::BadParameter>(m, "BadParameter", exc.ptr());
+  py::register_exception<bufr::BadValue>(m, "BadValue", exc.ptr());
+  py::register_exception<bufr::MissingData>(m, "MissingData", exc.ptr());
 
   setupDataContainer(m);
   setupQuerySet(m);

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -94,6 +94,7 @@ list( APPEND test_input
   testinput/bufrtest_python_mpi_test.py
   testinput/bufrtest_python_obsbuilder.py
   testinput/bufrtest_python_obsbuilder_mod_sig.py
+  testinput/bufrtest_python_exceptions.py
 )
 
 # create test directories and make links to the input files
@@ -577,6 +578,12 @@ if (${BUILD_PYTHON_BINDINGS})
                     TYPE    SCRIPT
                     COMMAND python3
                     ARGS    testinput/bufrtest_python_obsbuilder_mod_sig.py
+                    ENVIRONMENT PYTHONPATH=${CMAKE_BINARY_DIR}/lib/python${Python3_VERSION_MAJOR}.${Python3_VERSION_MINOR}/site-packages:$ENV{PYTHONPATH})
+
+  ecbuild_add_test( TARGET  test_bufr_python_exceptions
+                    TYPE    SCRIPT
+                    COMMAND python3
+                    ARGS    testinput/bufrtest_python_exceptions.py
                     ENVIRONMENT PYTHONPATH=${CMAKE_BINARY_DIR}/lib/python${Python3_VERSION_MAJOR}.${Python3_VERSION_MINOR}/site-packages:$ENV{PYTHONPATH})
 
 endif()

--- a/test/testinput/bufrtest_python_exceptions.py
+++ b/test/testinput/bufrtest_python_exceptions.py
@@ -1,0 +1,35 @@
+import bufr
+
+
+def test_catch_exceptions():
+    try:
+        raise bufr.BadParameter("bad param")
+    except bufr.BadParameter:
+        pass
+    else:
+        assert False, "BadParameter not caught"
+
+    try:
+        raise bufr.BadValue("bad value")
+    except bufr.BadValue:
+        pass
+    else:
+        assert False, "BadValue not caught"
+
+    try:
+        raise bufr.MissingData("missing")
+    except bufr.MissingData:
+        pass
+    else:
+        assert False, "MissingData not caught"
+
+    try:
+        raise bufr.Exception("generic")
+    except bufr.Exception:
+        pass
+    else:
+        assert False, "Exception not caught"
+
+
+if __name__ == "__main__":
+    test_catch_exceptions()


### PR DESCRIPTION
## Summary
- expose custom BUFR exceptions through the Python bindings
- document the new Python exception classes
- add unit test covering the new exception classes

## Testing
- `ctest --output-on-failure`
- `make -C docs html` *(fails: sphinx-build not found)*

------
https://chatgpt.com/codex/tasks/task_e_683e238065c083259d744b934bbd653f