### PR TITLE
Improved Handling for no found data.

### DIFF
--- a/core/include/bufr/DataProvider.h
+++ b/core/include/bufr/DataProvider.h
@@ -67,7 +67,7 @@ namespace bufr {
         bool isInteger() const { return scale <= 0; }
         bool is64Bit() const
         {
-            if (bits == 0) return false;
+            if (isUnknown()) return false;
 
             bool is64Bit;
             if (isInteger() && !isSigned())
@@ -90,6 +90,11 @@ namespace bufr {
         bool isLongString() const
         {
             return isString() && bits > 64;
+        }
+
+        bool isUnknown() const
+        {
+            return (bits == 0);
         }
     };
 

--- a/core/include/bufr/ResultSet.h
+++ b/core/include/bufr/ResultSet.h
@@ -49,6 +49,14 @@ namespace bufr {
                                         const std::string& groupByFieldName = "",
                                         const std::string& overrideType     = "") const;
 
+
+    /// \brief Discover the type of a field in the result set.
+    /// \param comm The MPI communicator to use for resolving the type.
+    /// \param fieldName The name of the field to resolve the type for.
+    /// \return The type of the field as a string.
+    std::string  resolveType(const eckit::mpi::Comm& comm,
+                             const std::string& fieldName) const;
+
     friend class QueryRunner;
 
    private:

--- a/core/src/bufr/BufrReader/BufrParser.cpp
+++ b/core/src/bufr/BufrReader/BufrParser.cpp
@@ -139,7 +139,12 @@ namespace bufr {
       {
         for (const auto& queryInfo : var->getQueryList())
         {
-          auto typeStr =  resultSet.resolveType(comm, queryInfo.name);
+          auto typeStr = queryInfo.type;
+          if (typeStr.empty())
+          {
+            typeStr =  resultSet.resolveType(comm, queryInfo.name);
+          }
+
           srcData[queryInfo.name] = resultSet.get(
             queryInfo.name, queryInfo.groupByField, typeStr);
         }

--- a/core/src/bufr/BufrReader/BufrParser.cpp
+++ b/core/src/bufr/BufrReader/BufrParser.cpp
@@ -139,8 +139,9 @@ namespace bufr {
       {
         for (const auto& queryInfo : var->getQueryList())
         {
+          auto typeStr =  resultSet.resolveType(comm, queryInfo.name);
           srcData[queryInfo.name] = resultSet.get(
-            queryInfo.name, queryInfo.groupByField, queryInfo.type);
+            queryInfo.name, queryInfo.groupByField, typeStr);
         }
       }
 

--- a/core/src/bufr/BufrReader/Query/DataProvider/DataProvider.cpp
+++ b/core/src/bufr/BufrReader/Query/DataProvider/DataProvider.cpp
@@ -10,6 +10,8 @@
 
 #include "eckit/exception/Exceptions.h"
 
+#include "../../../Log.h"
+
 
 namespace bufr {
     void DataProvider::run(const QuerySet& querySet,
@@ -71,20 +73,17 @@ namespace bufr {
 
         if (!foundBufrMsg)
         {
-            std::ostringstream errStr;
-            errStr << "No BUFR messages were found! ";
-            errStr << "Please make sure that " << filePath_ << " exists and is a valid BUFR file.";
-            throw eckit::BadValue(errStr.str());
+            std::ostringstream warnStr;
+            warnStr << "WARNING: No BUFR messages were found in ";
+            warnStr << filePath_ << "." << std::endl;
+            log::warning() << warnStr.str();
         }
-
-        if (!foundBufrSubset)
+        else if (!foundBufrSubset)
         {
-            std::ostringstream errStr;
-            errStr << "No valid BUFR subsets were found from your queries! ";
-            errStr << "Please make sure you are querying for valid subsets that exist in ";
-            errStr << filePath_ << ". ";
-            errStr << "Otherwise there might be a problem with the BUFR file (no subsets).";
-            throw eckit::BadValue(errStr.str());
+            std::ostringstream warnStr;
+            warnStr << "WARNING: No valid BUFR subsets were found from your queries in ";
+            warnStr << filePath_ << "." << std::endl;
+            log::warning() << warnStr.str();
         }
     }
 

--- a/core/src/bufr/BufrReader/Query/ResultSet.cpp
+++ b/core/src/bufr/BufrReader/Query/ResultSet.cpp
@@ -17,7 +17,13 @@ namespace bufr {
                                                  const std::string& groupByFieldName,
                                                  const std::string& overrideType) const
   {
-        return impl_->get(fieldName, groupByFieldName, overrideType);
+    return impl_->get(fieldName, groupByFieldName, overrideType);
+  }
+
+  std::string ResultSet::resolveType(const eckit::mpi::Comm& comm,
+                                     const std::string& fieldName) const
+  {
+    return impl_->resolveType(comm, fieldName);
   }
 
 }  // namespace bufr

--- a/core/src/bufr/BufrReader/Query/ResultSetImpl.cpp
+++ b/core/src/bufr/BufrReader/Query/ResultSetImpl.cpp
@@ -2,6 +2,7 @@
 
 #include "ResultSetImpl.h"
 
+#include <array>
 #include <algorithm>
 #include <iostream>
 #include <string>
@@ -111,19 +112,33 @@ namespace bufr {
       }
     }
 
-    for (size_t bitIdx=0; bitIdx < bits.size(); ++bitIdx)
+    const std::vector<std::string> precedence = {"string", "uint32", "uint64", "int32", "int64", "float", "double"};
+
+    size_t highestPrecedence = 0;
+    for (size_t taskIdx = 0; taskIdx < comm.size(); ++taskIdx)
     {
-      if (bits[bitIdx] != 0)
+      TypeInfo taskTypeInfo;
+      taskTypeInfo.bits = bits[taskIdx];
+      taskTypeInfo.scale = scale[taskIdx];
+      taskTypeInfo.reference = reference[taskIdx];
+      taskTypeInfo.unit = unit[taskIdx];
+
+      auto taskTypeStr = DataObjectBuilder::typeString(taskTypeInfo);
+      auto precIt = std::find(precedence.begin(), precedence.end(), taskTypeStr);
+      if (precIt != precedence.end())
       {
-        typeInfo.bits = bits[bitIdx];
-        typeInfo.scale = scale[bitIdx];
-        typeInfo.reference = reference[bitIdx];
-        typeInfo.unit = unit[bitIdx];
-        break;
+        auto precIdx = static_cast<size_t>(std::distance(precedence.begin(), precIt));
+        highestPrecedence = std::max(highestPrecedence, precIdx);
+      }
+      else
+      {
+        std::ostringstream errMsg;
+        errMsg << "Unkonwn type " << taskTypeStr << " encountered in ResultSet::resolveType." << std::endl;
+        throw eckit::BadParameter(errMsg.str());
       }
     }
 
-    return DataObjectBuilder::typeString(typeInfo);
+    return precedence[highestPrecedence];
   }
 
   details::TargetMetaDataPtr ResultSetImpl::analyzeTarget(const std::string& name) const {

--- a/core/src/bufr/BufrReader/Query/ResultSetImpl.cpp
+++ b/core/src/bufr/BufrReader/Query/ResultSetImpl.cpp
@@ -6,6 +6,7 @@
 #include <iostream>
 #include <string>
 
+#include "eckit/mpi/Comm.h"
 #include "eckit/exception/Exceptions.h"
 
 #include "VectorMath.h"
@@ -18,10 +19,28 @@ namespace bufr {
                                                      const std::string& groupByFieldName,
                                                      const std::string& overrideType) const
 {
-    // Make sure we have accumulated frames otherwise something is wrong.
     if (frames_.size() == 0)
     {
-      throw eckit::BadValue("ResultSet has no data.");
+      static bool printWarning = true;
+      if (printWarning) {
+        std::cerr << "WARNING: ResultSet has no frames. Returning empty DataObject." << std::endl;
+        printWarning = false;
+      }
+
+      auto data = details::ResultData();
+      data.buffer = {};
+      data.dims = {0};
+      data.dimPaths = {Query()};
+
+      auto object = DataObjectBuilder::make(fieldName,
+                                            groupByFieldName,
+                                            TypeInfo(),
+                                            overrideType,
+                                            data.buffer,
+                                            data.dims,
+                                            data.dimPaths);
+
+      return object;
     }
 
     // Get the metadata for the target
@@ -43,6 +62,67 @@ namespace bufr {
                                           data.dimPaths);
 
     return object;
+  }
+
+  std::string ResultSetImpl::resolveType(const eckit::mpi::Comm& comm,
+                                         const std::string& fieldName) const
+  {
+    TypeInfo typeInfo;
+    if (!frames_.empty())
+    {
+      typeInfo = analyzeTarget(fieldName)->typeInfo;
+    }
+
+    std::vector<int> bits(comm.size());
+    std::vector<int> scale(comm.size());
+    std::vector<int> reference(comm.size());
+
+    comm.allGather(typeInfo.bits, bits.begin(), bits.end());
+    comm.allGather(typeInfo.scale, scale.begin(), scale.end());
+    comm.allGather(typeInfo.reference, reference.begin(), reference.end());
+
+    std::vector<std::string> unit(comm.size());
+    {
+      size_t charsToSend = typeInfo.unit.size();
+
+      size_t charsToReceive = charsToSend;
+      comm.allReduce(charsToReceive, charsToReceive, eckit::mpi::Operation::SUM);
+
+      auto sizeArray = std::vector<int>(comm.size());
+      comm.allGather(static_cast<int>(charsToSend), sizeArray.begin(), sizeArray.end());
+
+      std::vector<char> rcvBuffer(charsToReceive, 0);
+      auto rcvCounts = std::vector<int>(comm.size());
+
+      std::vector<int> displacement(comm.size(), 0);
+      for (size_t i = 1; i < comm.size(); i++)
+      {
+        displacement[i] = displacement[i - 1] + sizeArray[i - 1];
+      }
+
+      comm.allGatherv(typeInfo.unit.begin(), typeInfo.unit.end(), rcvBuffer.begin(),
+                      sizeArray.data(), displacement.data());
+
+      for (size_t i = 0; i < comm.size(); i++)
+      {
+        unit[i] = std::string(rcvBuffer.begin() + displacement[i],
+                              rcvBuffer.begin() + displacement[i] + sizeArray[i]);
+      }
+    }
+
+    for (size_t bitIdx=0; bitIdx < bits.size(); ++bitIdx)
+    {
+      if (bits[bitIdx] != 0)
+      {
+        typeInfo.bits = bits[bitIdx];
+        typeInfo.scale = scale[bitIdx];
+        typeInfo.reference = reference[bitIdx];
+        typeInfo.unit = unit[bitIdx];
+        break;
+      }
+    }
+
+    return DataObjectBuilder::typeString(typeInfo);
   }
 
   details::TargetMetaDataPtr ResultSetImpl::analyzeTarget(const std::string& name) const {

--- a/core/src/bufr/BufrReader/Query/ResultSetImpl.cpp
+++ b/core/src/bufr/BufrReader/Query/ResultSetImpl.cpp
@@ -111,7 +111,8 @@ namespace bufr {
       }
     }
 
-    const std::vector<std::string> precedence = {"string", "uint32", "uint64", "int32", "int64", "float", "double"};
+    const std::vector<std::string> precedence = {"unknown", "string", "uint32", "uint64",
+                                              "int32", "int64", "float", "double"};
 
     size_t highestPrecedence = 0;
     for (size_t taskIdx = 0; taskIdx < comm.size(); ++taskIdx)

--- a/core/src/bufr/BufrReader/Query/ResultSetImpl.cpp
+++ b/core/src/bufr/BufrReader/Query/ResultSetImpl.cpp
@@ -12,6 +12,7 @@
 #include "VectorMath.h"
 #include "bufr/DataObject.h"
 #include "../../DataObjectBuilder.h"
+#include "../../Log.h"
 
 
 namespace bufr {
@@ -23,7 +24,7 @@ namespace bufr {
     {
       static bool printWarning = true;
       if (printWarning) {
-        std::cerr << "WARNING: ResultSet has no frames. Returning empty DataObject." << std::endl;
+        log::warning() << "WARNING: ResultSet has no frames. Returning empty DataObjects." << std::endl;
         printWarning = false;
       }
 

--- a/core/src/bufr/BufrReader/Query/ResultSetImpl.cpp
+++ b/core/src/bufr/BufrReader/Query/ResultSetImpl.cpp
@@ -2,7 +2,6 @@
 
 #include "ResultSetImpl.h"
 
-#include <array>
 #include <algorithm>
 #include <iostream>
 #include <string>
@@ -25,7 +24,7 @@ namespace bufr {
     {
       static bool printWarning = true;
       if (printWarning) {
-        log::warning() << "WARNING: ResultSet has no frames. Returning empty DataObjects." << std::endl;
+        log::warning() << "WARNING: ResultSet is empty. Returning empty DataObjects." << std::endl;
         printWarning = false;
       }
 

--- a/core/src/bufr/BufrReader/Query/ResultSetImpl.h
+++ b/core/src/bufr/BufrReader/Query/ResultSetImpl.h
@@ -75,6 +75,13 @@ namespace details
             const std::string& groupByFieldName = "",
             const std::string& overrideType = "") const;
 
+        /// \brief Discover the type of a field in the result set.
+        /// \param comm The MPI communicator to use for resolving the type.
+        /// \param fieldName The name of the field to resolve the type for.
+        /// \return The type of the field as a string.
+        std::string  resolveType(const eckit::mpi::Comm& comm,
+                                 const std::string& fieldName) const;
+
         friend class QueryRunner;
 
      private:

--- a/core/src/bufr/DataObjectBuilder.h
+++ b/core/src/bufr/DataObjectBuilder.h
@@ -74,7 +74,7 @@ namespace bufr {
     {
       std::string typeString;
       if (info.isUnknown()) {
-        typeString = "uint32";
+        typeString = "unknown";
       }
       else if (info.isString() || info.isLongString()) {
         typeString = "string";
@@ -97,7 +97,7 @@ namespace bufr {
     {
       std::shared_ptr<DataObjectBase> object;
       if (info.isUnknown()) {
-        object = std::make_shared<DataObject<uint32_t>>();
+        object = std::make_shared<DataObject<int32_t>>();
       }
       else if (info.isString() || info.isLongString()) {
         object = std::make_shared<DataObject<std::string>>();

--- a/core/src/bufr/DataObjectBuilder.h
+++ b/core/src/bufr/DataObjectBuilder.h
@@ -73,7 +73,10 @@ namespace bufr {
     static std::string typeString(const TypeInfo& info)
     {
       std::string typeString;
-      if (info.isString()) {
+      if (info.isUnknown()) {
+        typeString = "uint32";
+      }
+      else if (info.isString() || info.isLongString()) {
         typeString = "string";
       } else if (info.isInteger()) {
         if (info.isSigned()) {
@@ -93,8 +96,10 @@ namespace bufr {
     static std::shared_ptr<DataObjectBase> objectByTypeInfo(const TypeInfo& info)
     {
       std::shared_ptr<DataObjectBase> object;
-
-      if (info.isString() || info.isLongString()) {
+      if (info.isUnknown()) {
+        object = std::make_shared<DataObject<uint32_t>>();
+      }
+      else if (info.isString() || info.isLongString()) {
         object = std::make_shared<DataObject<std::string>>();
       } else if (info.isInteger()) {
         if (info.isSigned()) {

--- a/core/src/bufr/DataObjectBuilder.h
+++ b/core/src/bufr/DataObjectBuilder.h
@@ -33,7 +33,7 @@ namespace bufr {
       {
         object = objectByType(overrideType);
 
-        if ((overrideType == "string" && !info.isString())
+        if ((overrideType == "string" && (!info.isString() && !info.isUnknown()))
             || (overrideType != "string" && info.isString())) {
           std::ostringstream errMsg;
           errMsg << "Conversions between numbers and strings are not currently supported. ";
@@ -68,6 +68,24 @@ namespace bufr {
       object->setQuery(query);
 
       return object;
+    }
+
+    static std::string typeString(const TypeInfo& info)
+    {
+      std::string typeString;
+      if (info.isString()) {
+        typeString = "string";
+      } else if (info.isInteger()) {
+        if (info.isSigned()) {
+          typeString = info.is64Bit() ? "int64" : "int32";
+        } else {
+          typeString = info.is64Bit() ? "uint64" : "uint32";
+        }
+      } else {
+        typeString = info.is64Bit() ? "double" : "float";
+      }
+
+      return typeString;
     }
 
   private:

--- a/core/src/encoders/EncoderBase.cpp
+++ b/core/src/encoders/EncoderBase.cpp
@@ -82,6 +82,15 @@ namespace encoders {
           }
         }
       }
+      else if (varObj->size() == 0)  // Empty data object.
+      {
+        size_t dimIdx = 0;
+        for (const auto& chunkSize : var.chunks)
+        {
+          varChunkMap[var.name].push_back(0);
+          dimIdx++;
+        }
+      }
       else
       {
         if (var.chunks.size() != varObj->getDimPaths().size())

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -94,6 +94,7 @@ list( APPEND test_input
   testinput/bufrtest_python_mpi_test.py
   testinput/bufrtest_python_obsbuilder.py
   testinput/bufrtest_python_obsbuilder_mod_sig.py
+  testinput/bufrtest_missing_subset_mapping.yaml
 )
 
 # create test directories and make links to the input files
@@ -528,6 +529,13 @@ ecbuild_add_test( TARGET  test_bufr_dim_labels
                                                                  testinput/bufrtest_dim_labels_mapping.yaml
                                                                  testrun/bufrtest_hrs_basic.nc"
   bufrtest_hrs_basic.nc)
+
+ecbuild_add_test( TARGET  test_missing_subset_data
+                  TYPE    SCRIPT
+                  COMMAND ${CMAKE_BINARY_DIR}/bin/bufr2netcdf.x
+                  ARGS    " testdata/gdas.t00z.1bhrs4.tm00.bufr_d
+                            testinput/bufrtest_missing_subset_mapping.yaml
+                            testrun/empty.nc")
 
 ecbuild_add_test( TARGET  test_bufr_show_queries_ncep
                   TYPE    SCRIPT

--- a/test/testinput/bufrtest_missing_subset_mapping.yaml
+++ b/test/testinput/bufrtest_missing_subset_mapping.yaml
@@ -1,6 +1,8 @@
 # (C) Copyright 2023 NOAA/NWS/NCEP/EMC
 
 bufr:
+  subsets:
+    - MISSING
   variables:
     timestamp:
       datetime:

--- a/test/testinput/bufrtest_missing_subset_mapping.yaml
+++ b/test/testinput/bufrtest_missing_subset_mapping.yaml
@@ -1,4 +1,4 @@
-# (C) Copyright 2023 NOAA/NWS/NCEP/EMC
+# (C) Copyright 2025 NOAA/NWS/NCEP/EMC
 
 bufr:
   subsets:

--- a/test/testinput/bufrtest_missing_subset_mapping.yaml
+++ b/test/testinput/bufrtest_missing_subset_mapping.yaml
@@ -1,0 +1,54 @@
+# (C) Copyright 2023 NOAA/NWS/NCEP/EMC
+
+bufr:
+  variables:
+    timestamp:
+      datetime:
+        year: "*/YEAR"
+        month: "*/MNTH"
+        day: "*/DAYS"
+        hour: "*/HOUR"
+        minute: "*/MINU"
+        second: "*/SECO"
+    longitude:
+      query: "*/CLON"
+    latitude:
+      query: "*/CLAT"
+    channel:
+      query: "[*/BRITCSTC/CHNM, */BRIT/CHNM]"
+    brightnessTemp:
+      query: "[*/BRITCSTC/TMBR, */BRIT/TMBR]"
+
+encoder:
+
+  dimensions:
+    - name: Channel
+      paths:
+        - "*/BRIT"
+        - "*/BRITCSTC"
+      source: variables/channel
+
+  variables:
+    - name: "MetaData/dateTime"
+      source: variables/timestamp
+      longName: "dateTime"
+      units: "seconds since 1970-01-01T00:00:00Z"
+
+    - name: "MetaData/latitude"
+      source: variables/latitude
+      longName: "Latitude"
+      units: "degrees_north"
+      range: [-90, 90]
+
+    - name: "MetaData/longitude"
+      source: variables/longitude
+      longName: "Longitude"
+      units: "degrees_east"
+      range: [-180, 180]
+
+    - name: "ObsValue/brightnessTemperature"
+      coordinates: "longitude latitude Channel"
+      source: variables/brightnessTemp
+      longName: "Brightness temperature"
+      units: "K"
+      range: [120, 500]


### PR DESCRIPTION
This pull request improves the handling of situations where you might have an empty BUFR file or your queries might result in an empty data set because the subsets you listed might not exist. This situation (empty data set) was treated as an exception. This pull request treats it as a warning instead, and does not generate an exception.

Part of this was to add a type resolution process between the MPI tasks so that they will all agree on the type of data object that an data field should be, and act accordingly.

Fixes #101 