### PR TITLE
ObsBuilder Bugfixes

### DIFF
--- a/python/bufr/obs_builder/add_main_functions.py
+++ b/python/bufr/obs_builder/add_main_functions.py
@@ -1,9 +1,11 @@
 
 import os
+import sys
 import inspect
 import functools
 import yaml
 import json
+import bufr
 
 def add_main_functions(cls, execute_main=True):
 
@@ -14,19 +16,14 @@ def add_main_functions(cls, execute_main=True):
             return cls()
 
     def default_main():
-        import sys
         import time
         import yaml
         import argparse
-        from bufr import mpi
         from bufr.obs_builder import Logger
 
         logger = Logger(os.path.basename(__file__))
 
         start_time = time.time()
-
-        mpi.App(sys.argv)
-        comm = mpi.Comm("world")
 
         create_file_sig = inspect.signature(create_obs_file)
 
@@ -85,6 +82,7 @@ def add_main_functions(cls, execute_main=True):
             if not isinstance(config, dict):
                 raise ValueError(f'Config must resolve to a dict.')
 
+            bufr.mpi.App(sys.argv)
             return getattr(make_obs_builder(config), method_name)(*args, **kwargs)
 
         # Use functools.wraps to copy name, docstring, etc., from the original method

--- a/python/bufr/obs_builder/map_path.py
+++ b/python/bufr/obs_builder/map_path.py
@@ -1,5 +1,6 @@
 
 import os
+import inspect
 
 def map_path(map_file_name, base_dir=None):
     """
@@ -18,8 +19,14 @@ def map_path(map_file_name, base_dir=None):
 
     :raises FileNotFoundError: If the resolved file path does not exist.
     """
-    root_dir = base_dir if base_dir is not None else os.getcwd()
-    path = os.path.join(root_dir, map_file_name)
+    if base_dir:
+        path = os.path.join(base_dir, map_file_name)
+    else:
+        caller_frame = inspect.stack()[1]
+        caller_file_path = caller_frame.filename
+        # Get the directory name of that file
+        caller_directory = os.path.dirname(os.path.abspath(caller_file_path))
+        path = os.path.join(caller_directory, map_file_name)
 
     if not os.path.exists(path):
         raise FileNotFoundError(f"Mapping file not found: {path}")


### PR DESCRIPTION
This pull request fixes two problems that were found while creating SPOC unit tests. They are as follows:

1) map_path - The intent of this function is to get the path of the YAML map in relation to the ObsBuilder module. They are always assumed to be in the same path. map_path needs to get the directory for the calling module and use that as the base directory.. it was not doing that correctly. It was getting the "working directory" which is not the right thing to do...

2) add_main_functions - The eckit mpi App needs to be initialized before calling comm variable related functions. Unfortunately this was not happening when you just import create_obs_file or create_obs_group module functions and trying to run them directly. This PR fixes that as well. It is now initialized in the "wrapper" that calls the associated class method of the ObjectBuilder.