### PR TITLE
Deleted Mpi app init

### DIFF
--- a/python/bufr/obs_builder/add_main_functions.py
+++ b/python/bufr/obs_builder/add_main_functions.py
@@ -82,7 +82,6 @@ def add_main_functions(cls, execute_main=True):
             if not isinstance(config, dict):
                 raise ValueError(f'Config must resolve to a dict.')
 
-            bufr.mpi.App(sys.argv)
             return getattr(make_obs_builder(config), method_name)(*args, **kwargs)
 
         # Use functools.wraps to copy name, docstring, etc., from the original method


### PR DESCRIPTION
I was trying to be too clever and initialize the MPI app from the create functions that are added as part of an obsbuilders main interface. The problem is that this can lead to the initialization being called multiple times which creates a problem...