### PR TITLE
Optional override finalize_container.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .idea
 .vs
 .vscode
+.venv
 /CMakeSettings.json
 *~
 build

--- a/python/bufr/obs_builder/obs_builder.py
+++ b/python/bufr/obs_builder/obs_builder.py
@@ -39,7 +39,7 @@ class ObsBuilder:
         self.config = config
         self.description = self._make_description()
 
-    # Virtual Method
+    # Virtual Methods
     def make_obs(self, comm, input : Union[str, dict]) -> bufr.DataContainer:
         """
         This method is the main method that can be overridden (optional). Its objective is to read
@@ -65,6 +65,15 @@ class ObsBuilder:
             container.append(bufr.Parser(input, mapping_path).parse(comm))
 
         return container
+
+    def finalize_container(self, container:bufr.DataContainer) -> None:
+        """
+        Virtual method which can be overridden if you need to update the assembled
+        DataContainer object (data from all the MPI tasks).
+
+        :param container: The DataContainer to Mutate
+        """
+        pass
 
     def _make_description(self) -> bufr.encoders.Description:
         """
@@ -97,6 +106,7 @@ class ObsBuilder:
 
         # Encode the data
         if comm.rank() == 0:
+            self.finalize_container(container)
             FILE_ENCODER_DICT[type](self.description).encode(container, output, append)
 
         self.log.info(f'Return the encoded data')
@@ -171,6 +181,8 @@ class ObsBuilder:
         self.log.info(f'Gather data from all tasks into all tasks')
         container.all_gather(comm)
 
+        self.finalize_container(container)
+
         self.log.info(f'Add container to cache')
         # Add the container to the cache
         bufr.DataCache.add(cache_input_path,
@@ -197,6 +209,8 @@ class ObsBuilder:
 
         container = self.make_obs(comm, input)
         container.all_gather(comm)
+
+        self.finalize_container(container)
 
         # Encode the data
         if not category:


### PR DESCRIPTION
In rare instances you might want to have a way to modify the data in the container after it has been assembled via a gather function (all the data from all the MPI tasks are gathered together). The optional override finalize_container gives you a chance to operate on the completely assembled container before it is encoded.