### PR TITLE
Ensure tools load local bufr_query

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,10 +81,10 @@ jobs:
             echo 'set -e -x' >> /workspace/build/run_tests.sh
             echo \"export PATH=$PATH\" >> /workspace/build/run_tests.sh
             echo \"export PYTHONPATH=$PYTHONPATH\" >> /workspace/build/run_tests.sh
-            echo \"export LD_LIBRARY_PATH=$LD_LIBRARY_PATH\" >> /workspace/build/run_tests.sh
+            echo \"export LD_LIBRARY_PATH=/workspace/build/lib:$LD_LIBRARY_PATH\" >> /workspace/build/run_tests.sh
             # echo 'export PATH=$PATH' >> /workspace/build/run_tests.sh
             # echo 'export PYTHONPATH=$PYTHONPATH' >> /workspace/build/run_tests.sh
-            # echo 'export LD_LIBRARY_PATH=$LD_LIBRARY_PATH' >> /workspace/build/run_tests.sh
+            # echo 'export LD_LIBRARY_PATH=/workspace/build/lib:$LD_LIBRARY_PATH' >> /workspace/build/run_tests.sh
             echo 'echo \"RUNNING TESTS as \$(whoami)\"' >> /workspace/build/run_tests.sh
             echo 'cd /workspace/build && ctest --output-on-failure' >> /workspace/build/run_tests.sh
           "
@@ -143,7 +143,7 @@ jobs:
             # echo 'set -e -x' >> /workspace/build/run_tests.sh
             # echo 'export PATH=$PATH' >> /workspace/build/run_tests.sh
             # echo 'export PYTHONPATH=$PYTHONPATH' >> /workspace/build/run_tests.sh
-            # echo 'export LD_LIBRARY_PATH=$LD_LIBRARY_PATH' >> /workspace/build/run_tests.sh
+            # echo 'export LD_LIBRARY_PATH=/workspace/build/lib:$LD_LIBRARY_PATH' >> /workspace/build/run_tests.sh
             # echo 'echo \"RUNNING TESTS as \$(whoami)\"' >> /workspace/build/run_tests.sh
             # echo 'cd /workspace/build && ctest --output-on-failure' >> /workspace/build/run_tests.sh
           "
@@ -186,7 +186,7 @@ jobs:
             echo "set -e -x" >> /workspace/build/run_tests.sh
             echo "export PATH=$PATH" >> /workspace/build/run_tests.sh
             echo "export PYTHONPATH=$PYTHONPATH" >> /workspace/build/run_tests.sh
-            echo "export LD_LIBRARY_PATH=$LD_LIBRARY_PATH" >> /workspace/build/run_tests.sh
+            echo "export LD_LIBRARY_PATH=/workspace/build/lib:$LD_LIBRARY_PATH" >> /workspace/build/run_tests.sh
             echo "echo \"RUNNING TESTS as \$(whoami)\"" >> /workspace/build/run_tests.sh
             echo "cd /workspace/build && ctest --output-on-failure" >> /workspace/build/run_tests.sh
             

--- a/tools/bufr2netcdf/CMakeLists.txt
+++ b/tools/bufr2netcdf/CMakeLists.txt
@@ -14,5 +14,5 @@ ecbuild_add_executable( TARGET  bufr2netcdf.x
                         SOURCES ${_srcs}
                         LIBS    ${_deps})
 
-AddApp(bufr2netcdf.x)
-set_target_properties(bufr2netcdf.x PROPERTIES BUILD_RPATH "${CMAKE_BINARY_DIR}/lib")
+addapp(bufr2netcdf.x)
+

--- a/tools/bufr2netcdf/CMakeLists.txt
+++ b/tools/bufr2netcdf/CMakeLists.txt
@@ -14,7 +14,5 @@ ecbuild_add_executable( TARGET  bufr2netcdf.x
                         SOURCES ${_srcs}
                         LIBS    ${_deps})
 
-GetInstallRpath(_rp)
-if(_rp)
-    set_target_properties(bufr2netcdf.x PROPERTIES INSTALL_RPATH "${_rp}")
-endif()
+AddApp(bufr2netcdf.x)
+set_target_properties(bufr2netcdf.x PROPERTIES BUILD_RPATH "${CMAKE_BINARY_DIR}/lib")

--- a/tools/show_queries/CMakeLists.txt
+++ b/tools/show_queries/CMakeLists.txt
@@ -1,4 +1,6 @@
 
+include(GNUInstallDirs)
+include(Targets)
 
 list(APPEND _deps
             bufr_query)
@@ -15,3 +17,6 @@ list(APPEND _srcs
 ecbuild_add_executable( TARGET  show_queries.x
                         SOURCES ${_srcs}
                         LIBS ${_deps})
+
+AddApp(show_queries.x)
+set_target_properties(show_queries.x PROPERTIES BUILD_RPATH "${CMAKE_BINARY_DIR}/lib")

--- a/tools/show_queries/CMakeLists.txt
+++ b/tools/show_queries/CMakeLists.txt
@@ -18,5 +18,5 @@ ecbuild_add_executable( TARGET  show_queries.x
                         SOURCES ${_srcs}
                         LIBS ${_deps})
 
-AddApp(show_queries.x)
-set_target_properties(show_queries.x PROPERTIES BUILD_RPATH "${CMAKE_BINARY_DIR}/lib")
+addapp(show_queries.x)
+


### PR DESCRIPTION
## Summary
- make bufr2netcdf.x respect standard app settings and load libs from the build tree
- apply the same treatment to show_queries.x
- force CI tests to preload libraries from `${{ CMAKE_BINARY_DIR }}/lib`

## Testing
- `apt-get -o Acquire::AllowInsecureRepositories=true update` *(fails: 403 Forbidden)*
- `cmake -S . -B build` *(fails: No CMAKE_Fortran_COMPILER could be found)*

------
https://chatgpt.com/codex/tasks/task_e_689cb3ab60e8832592dc4bd246f4d980