### PR TITLE
Remove the pvlib

### DIFF
--- a/python/bufr/transforms/__init__.py
+++ b/python/bufr/transforms/__init__.py
@@ -1,2 +1,2 @@
 from .wind import compute_wind_components 
-from .geometry import compute_solar_angles 
+# from .geometry import compute_solar_angles


### PR DESCRIPTION
The pvlib package, which was required by the SSMIS BUFR-to-IODA converter, has been removed because it cannot be installed or used in the production environment.