### PR TITLE
Improvements to deal with empty containers.

### DIFF
--- a/core/include/bufr/DataObject.h
+++ b/core/include/bufr/DataObject.h
@@ -737,6 +737,11 @@ namespace bufr {
       /// \param data The data object to append.
       void append(const std::shared_ptr<DataObjectBase>& data) final
       {
+        if (data->size() == 0)
+        {
+          return;
+        }
+        
         auto other = std::dynamic_pointer_cast<DataObject<T>>(data);
         if (!other)
         {
@@ -1326,6 +1331,11 @@ namespace bufr {
       /// \param data The data object to append.
       void append(const std::shared_ptr<DataObjectBase>& data) final
       {
+        if (data->size() == 0)
+        {
+          return;
+        }
+
         auto other = std::dynamic_pointer_cast<DataObject<std::string>>(data);
         if (!other)
         {

--- a/core/src/bufr/DataContainer.cpp
+++ b/core/src/bufr/DataContainer.cpp
@@ -245,16 +245,16 @@ namespace bufr {
 
   void DataContainer::append(const DataContainer& other)
   {
-    // The other DataContainer is empty, nothing to do.
-    if (other.size() == 0)
-    {
-      return;
-    }
-
     bool isEmpty = getFieldNames().empty();
 
     for (const auto &subCat: other.allSubCategories())
     {
+      // The other DataContainer is empty, nothing to do.
+      if (other.size(subCat) == 0)
+      {
+        continue;
+      }
+
       if (isEmpty)
       {
         categoryMap_ = other.categoryMap_;

--- a/core/src/bufr/DataContainer.cpp
+++ b/core/src/bufr/DataContainer.cpp
@@ -150,13 +150,19 @@ namespace bufr {
     return subCategory;
   }
 
-  size_t DataContainer::size(const SubCategory& categoryId) const {
+  size_t DataContainer::size(const SubCategory& categoryId) const
+  {
     if (dataSets_.find(categoryId) == dataSets_.end()) {
       std::ostringstream errStr;
       errStr << "ERROR: Category called " << makeSubCategoryStr(categoryId);
       errStr << " does not exist.";
 
       throw eckit::BadParameter(errStr.str());
+    }
+
+    if (dataSets_.at(categoryId).empty())
+    {
+      return 0;
     }
 
     return dataSets_.at(categoryId).begin()->second->getDims().at(0);
@@ -239,6 +245,12 @@ namespace bufr {
 
   void DataContainer::append(const DataContainer& other)
   {
+    // The other DataContainer is empty, nothing to do.
+    if (other.size() == 0)
+    {
+      return;
+    }
+
     bool isEmpty = getFieldNames().empty();
 
     for (const auto &subCat: other.allSubCategories())

--- a/python/py_data_container.cpp
+++ b/python/py_data_container.cpp
@@ -147,6 +147,9 @@ void setupDataContainer(py::module& m)
         py::arg("category"),
         "Get the data container for the sub category.")
    .def("list", &DataContainer::getFieldNames, "Get the field names.")
+   .def("size", &DataContainer::size,
+        py::arg("category") = std::vector<std::string>(),
+        "Get the size of the data container dataset")
    .def("append", &DataContainer::append,
         py::arg("other"),
         "Append contents of another container. Must have the same category map and fields.")


### PR DESCRIPTION
On the Ocelot project I encoutered problems when processing long runs of data (years). Once in a while you will run into a BUFR file that has no data in it. This caused issues when appending to other good data. The code in this PR makes the code more robust in this situation, so we can ignore the empty datasets and just move on...

Also exposes the "size" method on the DataContainer via the python interface.