### PR TITLE
Fix for MPI Encoder Performance Problem

### DIFF
--- a/core/include/bufr/DataObject.h
+++ b/core/include/bufr/DataObject.h
@@ -800,7 +800,7 @@ namespace bufr {
 
       /// \brief Get the raw data associated with this data object.
       /// \return The raw data.
-      std::vector<T> getRawData() const { return data_; }
+      const std::vector<T>& getRawData() const { return data_; }
 
       /// \brief Get the size of the data object.
       /// \return The size of the data object.
@@ -1426,7 +1426,7 @@ namespace bufr {
 
       /// \brief Get the raw data associated with this data object.
       /// \return The raw data.
-      std::vector<std::string> getRawData() const { return data_; }
+      const std::vector<std::string>& getRawData() const { return data_; }
 
       /// \brief Get the size of the data object.
       /// \return The size of the data object.

--- a/core/src/encoders/EncoderBase.cpp
+++ b/core/src/encoders/EncoderBase.cpp
@@ -238,9 +238,10 @@ namespace encoders {
         labels.resize(dataObject->getDims().back());
         if (const auto obj = std::dynamic_pointer_cast<DataObject<int>>(dataObject))
         {
+          auto rawData = obj->getRawData();
           for (size_t idx = 0; idx < labels.size(); idx++)
           {
-            labels[idx] = obj->getRawData()[idx];
+            labels[idx] = rawData[idx];
           }
         }
         else

--- a/core/src/encoders/EncoderBase.cpp
+++ b/core/src/encoders/EncoderBase.cpp
@@ -238,9 +238,10 @@ namespace encoders {
         labels.resize(dataObject->getDims().back());
         if (const auto obj = std::dynamic_pointer_cast<DataObject<int>>(dataObject))
         {
+          const auto& rawData = obj->getRawData();
           for (size_t idx = 0; idx < labels.size(); idx++)
           {
-            labels[idx] = obj->getRawData()[idx];
+            labels[idx] = rawData[idx]; 
           }
         }
         else

--- a/core/src/encoders/EncoderBase.cpp
+++ b/core/src/encoders/EncoderBase.cpp
@@ -238,10 +238,9 @@ namespace encoders {
         labels.resize(dataObject->getDims().back());
         if (const auto obj = std::dynamic_pointer_cast<DataObject<int>>(dataObject))
         {
-          auto rawData = obj->getRawData();
           for (size_t idx = 0; idx < labels.size(); idx++)
           {
-            labels[idx] = rawData[idx];
+            labels[idx] = obj->getRawData()[idx];
           }
         }
         else


### PR DESCRIPTION
It turns out that the encoder was slow when including the `source` field in the `dimension` specification in the encoder description. This was because the function `getRawData` on the DataObject returned a complete copy of the underlying source data. The way that the source field was generated would call this function over and over again, pointlessly re-copying the underlying source array over and over again.. This PR changes `getRawData` to return a constant reference to the data so we are no longer copying it. This should help improve the performance in other places as well (not just the encoder).
