### PR TITLE
Skip invalid subset and avoid unecessary target refs

### DIFF
--- a/core/src/bufr/BufrReader/Query/DataProvider/DataProvider.cpp
+++ b/core/src/bufr/BufrReader/Query/DataProvider/DataProvider.cpp
@@ -60,6 +60,11 @@ namespace bufr {
                 status_f(FileUnit, &bufrLoc, &il, &im);
                 updateData(bufrLoc);
 
+                if (getIsc(getInode()) <= getInode())
+                {
+                    continue;  // Invalid Subset
+                }
+
                 processSubset();
                 if (!continueProcessing()) break;
             }

--- a/core/src/bufr/BufrReader/Query/SubsetLookupTable.cpp
+++ b/core/src/bufr/BufrReader/Query/SubsetLookupTable.cpp
@@ -10,13 +10,12 @@ namespace bufr {
     SubsetLookupTable::SubsetLookupTable(const std::shared_ptr<DataProvider>& dataProvider,
                                          const std::shared_ptr<Targets>& targets) :
         targets_(targets),
-        lookupTable_(makeLookupTable(dataProvider, *targets))
+        lookupTable_(makeLookupTable(dataProvider))
     {
     }
 
     SubsetLookupTable::LookupTable
-    SubsetLookupTable::makeLookupTable(const std::shared_ptr<DataProvider>& dataProvider,
-                                       const Targets& targets) const
+    SubsetLookupTable::makeLookupTable(const std::shared_ptr<DataProvider>& dataProvider) const
     {
         auto lookupTable = LookupTable(dataProvider->getInode(),
                                        dataProvider->getIsc(dataProvider->getInode()));
@@ -26,20 +25,19 @@ namespace bufr {
 
         // Populate the lookup table with the counts and data corresponding to each BUFR node
         // we care about.
-        addCounts(dataProvider, targets, lookupTable, lookupMetaTable);
-        addData(dataProvider, targets, lookupTable, lookupMetaTable);
+        addCounts(dataProvider, lookupTable, lookupMetaTable);
+        addData(dataProvider, lookupTable, lookupMetaTable);
 
         return lookupTable;
     }
 
     void SubsetLookupTable::addCounts(const std::shared_ptr<DataProvider>& dataProvider,
-                                      const Targets &targets,
                                       LookupTable& lookup,
                                       LookupMetaTable& lookupMeta) const
     {
         // Add entries for all the path nodes in the targets that are containers (can contain)
         // children. Uses merged data from the Subset metadata and Query strings.
-        for (const auto& target : targets)
+        for (const auto& target : *targets_)
         {
             for (const auto& path : target->path)
             {
@@ -79,12 +77,11 @@ namespace bufr {
     }
 
     void SubsetLookupTable::addData(const std::shared_ptr<DataProvider>& dataProvider,
-                                    const Targets &targets,
                                     LookupTable& lookup,
                                     LookupMetaTable& lookupMeta) const
     {
         // Reserve space for the data in the lookup table by summing the counts for each node.
-        for (const auto& target : targets)
+        for (const auto& target : *targets_)
         {
             if (target->nodeIdx == 0) { continue; }
             const auto &path = target->path.back();

--- a/core/src/bufr/BufrReader/Query/SubsetLookupTable.h
+++ b/core/src/bufr/BufrReader/Query/SubsetLookupTable.h
@@ -97,6 +97,7 @@ namespace bufr {
         LookupTable lookupTable_;
 
         /// \brief Creates a lookup table that maps node ids to NodeData objects.
+        /// \param[in] dataProvider The data provider to get the data from.
         /// \return The lookup table.
         LookupTable makeLookupTable(const std::shared_ptr<DataProvider>& dataProvider) const;
 

--- a/core/src/bufr/BufrReader/Query/SubsetLookupTable.h
+++ b/core/src/bufr/BufrReader/Query/SubsetLookupTable.h
@@ -112,7 +112,7 @@ namespace bufr {
 
         /// \brief Adds the data for the targets to the lookup table.
         /// \param[in] dataProvider The data provider to get the data from.
-        /// \param[in, out] lookup The lookup table to add the data to
+        /// \param[in, out] lookup The lookup table to add the data to.
         /// \param[in, out] lookupMeta The lookup meta table that tracks the nodes to collect
         ///                            and other meta data.
         void addData(const std::shared_ptr<DataProvider>& dataProvider,

--- a/core/src/bufr/BufrReader/Query/SubsetLookupTable.h
+++ b/core/src/bufr/BufrReader/Query/SubsetLookupTable.h
@@ -104,7 +104,7 @@ namespace bufr {
         /// \brief Adds the counts data for the targets to the lookup table.
         /// \param[in] dataProvider The data provider to get the data from.
         /// \param[in, out] lookup The lookup table to add the counts data to.
-        /// \param[in, out] lookupMeta The lookup meta table that tracks the node to collect
+        /// \param[in, out] lookupMeta The lookup meta table that tracks the nodes to collect
         ///                            and other meta data.
         void addCounts(const std::shared_ptr<DataProvider>& dataProvider,
                        LookupTable& lookup,

--- a/core/src/bufr/BufrReader/Query/SubsetLookupTable.h
+++ b/core/src/bufr/BufrReader/Query/SubsetLookupTable.h
@@ -97,20 +97,23 @@ namespace bufr {
         LookupTable lookupTable_;
 
         /// \brief Creates a lookup table that maps node ids to NodeData objects.
-        /// \param[in] targets The targets to create the lookup table for.
         /// \return The lookup table.
         LookupTable makeLookupTable(const std::shared_ptr<DataProvider>& dataProvider) const;
 
-        /// \brief Adds the counts data for the given targets to the lookup table.
-        /// \param[in] targets The targets to add the counts data for.
+        /// \brief Adds the counts data for the targets to the lookup table.
+        /// \param[in] dataProvider The data provider to get the data from.
         /// \param[in, out] lookup The lookup table to add the counts data to.
+        /// \param[in, out] lookupMeta The lookup meta table that tracks the node to collect
+        ///                            and other meta data.
         void addCounts(const std::shared_ptr<DataProvider>& dataProvider,
                        LookupTable& lookup,
                        LookupMetaTable& lookupMeta) const;
 
-        /// \brief Adds the data for the given targets to the lookup table.
-        /// \param[in] targets The targets to add the data for.
-        /// \param[in, out] lookup The lookup table to add the data to.
+        /// \brief Adds the data for the targets to the lookup table.
+        /// \param[in] dataProvider The data provider to get the data from.
+        /// \param[in, out] lookup The lookup table to add the data to
+        /// \param[in, out] lookupMeta The lookup meta table that tracks the nodes to collect
+        ///                            and other meta data.
         void addData(const std::shared_ptr<DataProvider>& dataProvider,
                      LookupTable& lookup,
                      LookupMetaTable& lookupMeta) const;

--- a/core/src/bufr/BufrReader/Query/SubsetLookupTable.h
+++ b/core/src/bufr/BufrReader/Query/SubsetLookupTable.h
@@ -99,14 +99,12 @@ namespace bufr {
         /// \brief Creates a lookup table that maps node ids to NodeData objects.
         /// \param[in] targets The targets to create the lookup table for.
         /// \return The lookup table.
-        LookupTable makeLookupTable(const std::shared_ptr<DataProvider>& dataProvider,
-                                    const Targets& targets) const;
+        LookupTable makeLookupTable(const std::shared_ptr<DataProvider>& dataProvider) const;
 
         /// \brief Adds the counts data for the given targets to the lookup table.
         /// \param[in] targets The targets to add the counts data for.
         /// \param[in, out] lookup The lookup table to add the counts data to.
         void addCounts(const std::shared_ptr<DataProvider>& dataProvider,
-                       const Targets& targets,
                        LookupTable& lookup,
                        LookupMetaTable& lookupMeta) const;
 
@@ -114,7 +112,6 @@ namespace bufr {
         /// \param[in] targets The targets to add the data for.
         /// \param[in, out] lookup The lookup table to add the data to.
         void addData(const std::shared_ptr<DataProvider>& dataProvider,
-                     const Targets& targets,
                      LookupTable& lookup,
                      LookupMetaTable& lookupMeta) const;
     };


### PR DESCRIPTION
On rare occasions you will run into a bad subset within a BUFR file. This may manifest itself in an exception that looks like the following:

```
  File "/scratch3/NCEPDEV/da/Nicholas.Esposito/ocelot/source/ocelot/data_prep/mapping/bufr_surface_obs_raw.py", line 36, in make_obs
    sfcshp_container = bufr.Parser(input_dict[SfcshpKey], self.map_dict[SfcshpKey]).parse(comm)
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ValueError: vector::_M_default_append
```

The error happens because we end up trying to resize an array to an invalid value as the bad subsets start and end indices don't make sense...


While I was at it I made a minor change to the SubsetLookupTable in order to avoid uneccessarily copying target refereneces around everywhere.

